### PR TITLE
Day 2: Finish creating random recipe route & start writing unit tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,5 @@
 import "dotenv/config"; // fetch secrets from .env
 import express from "express";
-
 import recipes from "./routes/recipes";
 
 const app = express();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
+        "@types/jest": "^28.1.3",
         "@types/node": "^18.0.0",
         "concurrently": "^7.2.2",
         "jest": "^28.1.1",
+        "ts-jest": "^28.0.5",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.7.4"
       }
@@ -1158,6 +1160,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+      "dev": true,
+      "dependencies": {
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -1527,6 +1539,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -3305,6 +3329,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4267,6 +4297,60 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "28.0.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.5.tgz",
+      "integrity": "sha512-Sx9FyP9pCY7pUzQpy4FgRZf2bhHY3za576HMKJFs+OnQ9jS96Du5vNsDKkyedQkik+sEabbKAnCliv9BEsHZgQ==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^28.0.0",
+        "json5": "^2.2.1",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "babel-jest": "^28.0.0",
+        "jest": "^28.0.0",
+        "typescript": ">=4.3"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ts-node": {
@@ -5547,6 +5631,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+      "dev": true,
+      "requires": {
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      }
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -5839,6 +5933,15 @@
         "electron-to-chromium": "^1.4.164",
         "node-releases": "^2.0.5",
         "update-browserslist-db": "^1.0.0"
+      }
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -7169,6 +7272,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7875,6 +7984,33 @@
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
+    },
+    "ts-jest": {
+      "version": "28.0.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.5.tgz",
+      "integrity": "sha512-Sx9FyP9pCY7pUzQpy4FgRZf2bhHY3za576HMKJFs+OnQ9jS96Du5vNsDKkyedQkik+sEabbKAnCliv9BEsHZgQ==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^28.0.0",
+        "json5": "^2.2.1",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "ts-node": {
       "version": "10.8.1",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/jest": "^28.1.3",
     "@types/node": "^18.0.0",
     "concurrently": "^7.2.2",
     "jest": "^28.1.1",
+    "ts-jest": "^28.0.5",
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.7.4"
   }

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -1,0 +1,34 @@
+import { getRandomElement } from "../utils/array";
+
+describe("getRandomElement", () => {
+  test("returns an element in the array", () => {
+    // Given an array with N elements
+    const array = [1, 2, 3];
+    // When getRandomElement() is called
+    const randomNum = getRandomElement(array);
+    // Then the element returned must be in the array
+    // Note: Math.random() doesn't provide a way to initalize a seed,
+    // so we can't guarantee the function returns a certain element
+    expect(array).toEqual(expect.arrayContaining([randomNum]));
+  });
+
+  test("returns the same element if the array's length is 1", () => {
+    // Given an array with one element
+    const array = ["chrysno"];
+    // When getRandomElement() is called
+    const randomString = getRandomElement(array);
+    // Then the function should return that one element
+    expect(randomString).toBe(array[0]);
+  });
+
+  test("throws an error if the array is empty", () => {
+    // Given an empty array
+    const emptyArray: object[] = [];
+    // When getRandomElement() is called
+    // Then the function should throw an error stating that the array
+    // must contain at least one element
+    expect(() => getRandomElement(emptyArray)).toThrowError(
+      "array must contain at least one element"
+    );
+  });
+});

--- a/utils/array.ts
+++ b/utils/array.ts
@@ -1,5 +1,17 @@
 // Helper methods for arrays
 
-// Get a random element from an array
-export const getRandomElement = <T>(array: Array<T>): T =>
-  array[Math.floor(Math.random() * array.length)];
+/**
+ * Get a random element from the provided array
+ * @param {Array<T>} array - the array
+ * @returns {T} a random element from `array`
+ * @throws if `array` is empty
+ */
+export const getRandomElement = <T>(array: Array<T>): T => {
+  if (array.length === 0) {
+    throw new Error(
+      "The array must contain at least one element to be randomly selected."
+    );
+  }
+
+  return array[Math.floor(Math.random() * array.length)];
+};

--- a/utils/array.ts
+++ b/utils/array.ts
@@ -1,0 +1,5 @@
+// Helper methods for arrays
+
+// Get a random element from an array
+export const getRandomElement = <T>(array: Array<T>): T =>
+  array[Math.floor(Math.random() * array.length)];

--- a/utils/recipeBuilder.ts
+++ b/utils/recipeBuilder.ts
@@ -1,0 +1,13 @@
+export const recipeBuilder = (): string => {
+  /*
+    Low-effort filter recipes
+    - Uses 5 or fewer ingredients
+    - Only uses common ingredients like chicken, potatoes, onions, and carrots. We want these recipes to be dishes people can put together with ingredients lying around the kitchen
+    - 1 hour or less of cook time
+    - Can make 3 or more servings
+    */
+  const appId = process.env.APPLICATION_ID;
+  const appKey = process.env.APPLICATION_KEY;
+  let url = `https://api.edamam.com/api/recipes/v2?type=public&app_id=${appId}&app_key=${appKey}&ingr=5&time=60&random=true`;
+  return encodeURI(url);
+};


### PR DESCRIPTION
I couldn't find a way to make the Edamam API return only one random recipe. There is an endpoint to fetch a specific recipe: `GET /api/recipes/v2/{id}`, but the only way to obtain a recipe ID is to query the recipes. Instead, I decided to make the following API call, which will fetch recipes with 5 or fewer ingredients and take less than an hour to make:

`GET https://api.edamam.com/api/recipes/v2?type=public&app_id={{appId}}&app_key={{appKey}}&ingr=5&time=60&random=true`

The results are paginated 20 recipes at a time in random order. So, I took those 20 recipes and randomly selected one of those in the router. I also parsed the response using the Recipes model I created on day 1. The downside is that the network call is a little expensive. But the server is ready to be consumed by a client (for the MVP). So I will merge this PR and create a new feature branch to start working on the Angular app.

As a bonus, I created some unit tests for the method I developed to select a random element from an array (since there's no method like it in vanilla JS). This should trigger the node.js workflow for each subsequent PR. (Before I forget, I should add the badges to the README.)