### PR TITLE
Day 12: Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,14 +20,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      # Allow npm to fetch a GitHub dependency
-      # Source: https://github.com/actions/setup-node/issues/214#issuecomment-810829250
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Fetch the latest LTS version of node
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+# Run the Angular app on port 4200 and open the connection
+EXPOSE 4200
+CMD [ "npm", "start", "--", "--host=0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+
+## Docker
+
+1. Build the Docker image: `docker build . -t TAG_NAME`
+2. Run the image in a container: `docker run --rm -p 4200:4200 -d TAG_NAME`
+3. Open `localhost:4200`
+
+Run `docker kill <container id>` to shut down the image when done. The container ID can be found using `docker ps`.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent {
 
     // Show a random, low-effort recipe
     // TODO: replace the mock call with the API call in prod
-    this.recipeService.getMockRecipe().subscribe({
+    this.recipeService.getRandomRecipe().subscribe({
       next: (recipe: Recipe) => {
         this.isLoading = false;
         this.recipe = recipe;


### PR DESCRIPTION
I added support for Docker. This is part 1 of trying to set up containers for both the client and the server. Once the MVP is ready, I plan to alter the Dockerfile to support prod builds on top of dev builds.

I also changed the recipe API to fetch from the server instead of the mock recipes. This should stay for builds merged to main, but it's ok to change that for other branches for ease of testing without a quota.