### PR TITLE
Day 19: Deploy Web MVP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 RUN npm install
-# If you are building your code for production
-# RUN npm ci --production
 
 # Bundle app source
 COPY . .

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY package*.json ./
 # The Angular CLI is a dev dependency that needs to be installed
-RUN npm ci --production && npm ci @angular/cli
+RUN npm ci --omit=dev && npm ci @angular/cli
 
 COPY . .
 # The build will be located in dist/project-name

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run `npm test` to run the unit tests using Karma.
 
 ### Build
 
-Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory.
+Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory. Then run `python3 -m http.server -d dist/ez-recipes/ PORT` to serve the page over a simple HTTP server. (By default, `PORT` is 8000.)
 
 ### Further Help
 

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -119,7 +119,6 @@ export class RecipeComponent implements OnInit, OnDestroy {
     this.isLoading = true;
 
     // Show a random, low-effort recipe
-    // TODO: replace the mock call with the API call in prod
     this.recipeService.getRandomRecipe().subscribe({
       next: (recipe: Recipe) => {
         this.isLoading = false;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  recipeBaseUrl: 'http://localhost:5000/api/recipes',
+  recipeBaseUrl: 'https://ez-recipes-server.onrender.com/api/recipes',
   mock: false,
 };


### PR DESCRIPTION
It's time to deploy the web app as well! This time, the Docker container in prod should already be set up, so the main change is to reference the server URL in the prod environment file. After this is merged, I will deploy to [render.com](https://render.com/) and publish the URL on GitHub and in the README. And like the server, changes to main will automatically get deployed to Render. Also, under the free tier, instances will sleep if they're inactive after a while, which will save on costs in exchange for a cold start when the user initially loads the page.