### PR TITLE
Add Well-Known Universal & App Links

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,8 @@
               "src/favicon.ico",
               "src/assets",
               "src/manifest.webmanifest",
-              "src/robots.txt"
+              "src/robots.txt",
+              "src/.well-known"
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css",
@@ -100,7 +101,8 @@
               "src/favicon.ico",
               "src/assets",
               "src/manifest.webmanifest",
-              "src/robots.txt"
+              "src/robots.txt",
+              "src/.well-known"
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css",

--- a/src/.well-known/apple-app-site-association
+++ b/src/.well-known/apple-app-site-association
@@ -1,0 +1,17 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "UF6E5BVT98.com.abhiek.EZ-Recipes"
+        ],
+        "components": [
+          {
+            "/": "/recipe/*",
+            "comment": "Maps the recipe pages on the web app to the recipe views on the iOS app"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/.well-known/assetlinks.json
+++ b/src/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.abhiek.ezrecipes",
+      "sha256_cert_fingerprints": [
+        "F1:99:EE:D8:6E:DB:E5:2B:08:6E:82:10:D1:F5:5B:2B:C6:68:7E:4F:45:EB:F5:BC:35:78:4A:A8:76:7C:DE:E9"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
I added `.well-known/apple-app-site-association` for universal links on iOS and `.well-known/assetlinks.json` for app links on Android. When the user opens a recipe page on a mobile browser and they have the mobile app installed, they will be prompted to open the same recipe page on the mobile app. Once this PR is merged, both files will be deployed on Render.

Per the [iOS specs](https://developer.apple.com/documentation/bundleresources/applinks), I combined the Team ID for my personal account and the bundle ID to form the App ID. (Team and App are capitalized, while bundle isn't to be consistent with [Apple's docs](https://developer.apple.com/library/archive/documentation/General/Conceptual/DevPedia-CocoaCore/AppID.html)). Per the [Android specs](https://developers.google.com/digital-asset-links/v1/statements), I provided the package name and the SHA256 fingerprint of Android Studio's default debug keystore. Later on, I will need to add the fingerprint of the release keystore, but since I'm using Play App Signing, Google manages the signing key, so the fingerprint will be different than the keystore I have locally for the upload key. I can get the fingerprint from the Play Console once we start deploying the Android app.

Related PRs:
- iOS: https://github.com/Abhiek187/ez-recipes-ios/pull/24
- Android: _to be added_