### PR TITLE
209 fix ingredients alignment on web

### DIFF
--- a/src/app/components/recipe/recipe.component.scss
+++ b/src/app/components/recipe/recipe.component.scss
@@ -138,7 +138,6 @@ $step-breakpoint: 800px;
   }
 
   .recipe-ingredients-card {
-    flex-basis: 300px;
     margin-left: auto;
     margin-right: auto;
 

--- a/src/app/components/recipe/recipe.component.scss
+++ b/src/app/components/recipe/recipe.component.scss
@@ -142,8 +142,8 @@ $step-breakpoint: 800px;
     margin-right: auto;
 
     @media screen and (max-width: $side-width-breakpoint) {
-      /* Make the ingredients label smaller on small screens */
-      width: 300px;
+      /* Make the ingredients label smaller on small screens, without overflowing */
+      width: min(calc(100vw - 24px), 300px);
     }
 
     .recipe-ingredients-header {


### PR DESCRIPTION
[git bisect](https://git-scm.com/docs/git-bisect) revealed the blame to be on the [Angular Material v15 upgrade](https://github.com/Abhiek187/ez-recipes-web/pull/122). After all that, it just took a couple of lines to fix it:

| Desktop | Mobile |
| - | - |
| ![localhost_4200_recipe_1096217(iPad Air)](https://github.com/Abhiek187/ez-recipes-web/assets/29958092/2e0e3d1f-ca5d-4f44-9068-bb165118a25c) | ![localhost_4200_recipe_1096217(Galaxy Fold)](https://github.com/Abhiek187/ez-recipes-web/assets/29958092/8523a8a1-231d-4ea9-aa48-f1dea818a641) |
