### PR TITLE
Finish Filter Form

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,11 +10,17 @@ import {
 import { HomeComponent } from './components/home/home.component';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 import { RecipeComponent } from './components/recipe/recipe.component';
-import { SearchComponent } from './components/search/search.component';
 
 export const routes: Record<string, Route> = {
   recipe: { path: 'recipe/:id', component: RecipeComponent },
-  search: { path: 'search', title: 'Search', component: SearchComponent },
+  search: {
+    path: 'search',
+    title: 'Search',
+    loadComponent: () =>
+      import('./components/search/search.component').then(
+        (mod) => mod.SearchComponent
+      ),
+  },
   // The default route should be listed between the static routes and wildcard routes
   home: { path: '', title: 'Home', component: HomeComponent },
   // Show a 404 page for any other route

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -1,20 +1,31 @@
-<mat-card (click)="openRecipe()">
-  <img mat-card-image [src]="recipe.image" [alt]="recipe.name" />
-  <mat-card-content>
-    <span>
+<!-- Treat the card like a button -->
+<mat-card
+  class="recipe-card"
+  role="button"
+  tabindex="0"
+  (click)="openRecipe()"
+  (keydown.enter)="openRecipe()"
+  (keydown.space)="openRecipe(); $event.preventDefault()"
+>
+  <img mat-card-image [src]="recipe.image" alt="" width="312" height="231" />
+  <mat-card-content class="recipe-content">
+    <span class="recipe-name-row">
       <mat-card-title>{{ recipe.name }}</mat-card-title>
       <button
         mat-icon-button
         [attr.aria-label]="
           (isFavorite ? 'Unfavorite' : 'Favorite') + ' this recipe'
         "
-        (click)="toggleFavoriteRecipe()"
+        (click)="toggleFavoriteRecipe($event)"
       >
-        <mat-icon [fontIcon]="isFavorite ? 'favorite' : 'favorite_border'" />
+        <mat-icon
+          [fontIcon]="isFavorite ? 'favorite' : 'favorite_border'"
+          color="warn"
+        />
       </button>
     </span>
-    <span>
-      <h2 [ngPlural]="recipe.time">
+    <span class="recipe-info-row">
+      <p [ngPlural]="recipe.time">
         <!-- Pluralize the recipe time (if a recipe only takes a minute) -->
         <ng-template ngPluralCase="1">
           <b>Time:</b> {{ recipe.time }} minute
@@ -22,7 +33,7 @@
         <ng-template ngPluralCase="other">
           <b>Time:</b> {{ recipe.time }} minutes
         </ng-template>
-      </h2>
+      </p>
 
       <p *ngIf="calories !== undefined">
         {{ calories.amount | number : "1.0-0" }} {{ calories.unit }}

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -13,6 +13,7 @@
       <mat-card-title>{{ recipe.name }}</mat-card-title>
       <button
         mat-icon-button
+        class="recipe-favorite-icon"
         [attr.aria-label]="
           (isFavorite ? 'Unfavorite' : 'Favorite') + ' this recipe'
         "

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -1,0 +1,32 @@
+<mat-card (click)="openRecipe()">
+  <img mat-card-image [src]="recipe.image" [alt]="recipe.name" />
+  <mat-card-content>
+    <span>
+      <mat-card-title>{{ recipe.name }}</mat-card-title>
+      <button
+        mat-icon-button
+        [attr.aria-label]="
+          (isFavorite ? 'Unfavorite' : 'Favorite') + ' this recipe'
+        "
+        (click)="toggleFavoriteRecipe()"
+      >
+        <mat-icon [fontIcon]="isFavorite ? 'favorite' : 'favorite_border'" />
+      </button>
+    </span>
+    <span>
+      <h2 [ngPlural]="recipe.time">
+        <!-- Pluralize the recipe time (if a recipe only takes a minute) -->
+        <ng-template ngPluralCase="1">
+          <b>Time:</b> {{ recipe.time }} minute
+        </ng-template>
+        <ng-template ngPluralCase="other">
+          <b>Time:</b> {{ recipe.time }} minutes
+        </ng-template>
+      </h2>
+
+      <p *ngIf="calories !== undefined">
+        {{ calories.amount | number : "1.0-0" }} {{ calories.unit }}
+      </p>
+    </span>
+  </mat-card-content>
+</mat-card>

--- a/src/app/components/recipe-card/recipe-card.component.scss
+++ b/src/app/components/recipe-card/recipe-card.component.scss
@@ -1,0 +1,26 @@
+.recipe-card:focus-visible {
+  // Source: https://stackoverflow.com/a/72790148
+  outline: none;
+  background-color: #efefef;
+  box-shadow: 0 3px 5px -1px #0003, 0 6px 10px #00000024, 0 1px 18px #0000001f;
+}
+
+.recipe-content {
+  > * {
+    display: flex;
+    align-items: center;
+    margin-top: 8px;
+  }
+
+  .recipe-name-row {
+    justify-content: space-around;
+  }
+
+  .recipe-info-row {
+    justify-content: space-evenly;
+
+    p {
+      font-size: 16px;
+    }
+  }
+}

--- a/src/app/components/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/recipe-card/recipe-card.component.spec.ts
@@ -74,12 +74,14 @@ describe('RecipeCardComponent', () => {
     // Check that isFavorite toggles when the heart button is clicked
     expect(recipeCardComponent.isFavorite).toBeFalse();
 
-    const clickEvent = new MouseEvent('click');
-    recipeCardComponent.toggleFavoriteRecipe(clickEvent);
+    const favoriteButton = rootElement.querySelector<HTMLButtonElement>(
+      '.recipe-favorite-icon'
+    );
+    favoriteButton?.click();
     fixture.detectChanges();
     expect(recipeCardComponent.isFavorite).toBeTrue();
 
-    recipeCardComponent.toggleFavoriteRecipe(clickEvent);
+    favoriteButton?.click();
     fixture.detectChanges();
     expect(recipeCardComponent.isFavorite).toBeFalse();
   });

--- a/src/app/components/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/recipe-card/recipe-card.component.spec.ts
@@ -1,30 +1,95 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 
 import { RecipeCardComponent } from './recipe-card.component';
 import { mockRecipe } from 'src/app/models/recipe.mock';
+import { RecipeService } from 'src/app/services/recipe.service';
 
 describe('RecipeCardComponent', () => {
-  let component: RecipeCardComponent;
+  let recipeCardComponent: RecipeCardComponent;
   let fixture: ComponentFixture<RecipeCardComponent>;
+  let rootElement: HTMLElement;
+
+  let mockRecipeService: jasmine.SpyObj<RecipeService>;
+  let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
+    mockRecipeService = jasmine.createSpyObj('RecipeService', ['setRecipe']);
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+
     await TestBed.configureTestingModule({
       imports: [
         RecipeCardComponent,
         HttpClientTestingModule,
         RouterModule.forRoot([]),
       ],
+      providers: [
+        {
+          provide: RecipeService,
+          useValue: mockRecipeService,
+        },
+        {
+          provide: Router,
+          useValue: mockRouter,
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RecipeCardComponent);
-    component = fixture.componentInstance;
-    component.recipe = mockRecipe; // input is required
+    recipeCardComponent = fixture.componentInstance;
+    recipeCardComponent.recipe = mockRecipe; // input is required
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should create a recipe card', () => {
+    // All elements should be visible on the recipe card
+    expect(recipeCardComponent).toBeTruthy();
+    expect(recipeCardComponent.calories).toEqual(
+      mockRecipe.nutrients.find((nutrient) => nutrient.name === 'Calories')
+    );
+
+    const recipeCard = rootElement.querySelector<HTMLElement>('.recipe-card');
+    expect(recipeCard).not.toBeNull();
+
+    const recipeImage = recipeCard?.querySelector<HTMLImageElement>('img');
+    expect(recipeImage?.src).toBe(mockRecipe.image);
+    expect(recipeImage?.alt).toBe('');
+
+    const recipeContent =
+      recipeCard?.querySelector<HTMLElement>('.recipe-content');
+    expect(recipeContent?.textContent).toContain(mockRecipe.name);
+    expect(recipeContent?.textContent).toContain(
+      `Time: ${mockRecipe.time} minutes`
+    );
+    expect(recipeContent?.textContent).toContain(
+      `${Math.round(recipeCardComponent.calories!.amount)} ${
+        recipeCardComponent.calories?.unit
+      }`
+    );
+  });
+
+  it('should toggle isFavorite', () => {
+    // Check that isFavorite toggles when the heart button is clicked
+    expect(recipeCardComponent.isFavorite).toBeFalse();
+
+    const clickEvent = new MouseEvent('click');
+    recipeCardComponent.toggleFavoriteRecipe(clickEvent);
+    fixture.detectChanges();
+    expect(recipeCardComponent.isFavorite).toBeTrue();
+
+    recipeCardComponent.toggleFavoriteRecipe(clickEvent);
+    fixture.detectChanges();
+    expect(recipeCardComponent.isFavorite).toBeFalse();
+  });
+
+  it('should open the selected recipe', () => {
+    // Check that the correct recipe is set and navigated to
+    recipeCardComponent.openRecipe();
+    expect(mockRecipeService.setRecipe).toHaveBeenCalledWith(mockRecipe);
+    expect(mockRouter.navigate).toHaveBeenCalledWith([
+      `/recipe/${mockRecipe.id}`,
+    ]);
   });
 });

--- a/src/app/components/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/recipe-card/recipe-card.component.spec.ts
@@ -1,0 +1,30 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+
+import { RecipeCardComponent } from './recipe-card.component';
+import { mockRecipe } from 'src/app/models/recipe.mock';
+
+describe('RecipeCardComponent', () => {
+  let component: RecipeCardComponent;
+  let fixture: ComponentFixture<RecipeCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        RecipeCardComponent,
+        HttpClientTestingModule,
+        RouterModule.forRoot([]),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecipeCardComponent);
+    component = fixture.componentInstance;
+    component.recipe = mockRecipe; // input is required
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/recipe-card/recipe-card.component.spec.ts
@@ -88,7 +88,8 @@ describe('RecipeCardComponent', () => {
 
   it('should open the selected recipe', () => {
     // Check that the correct recipe is set and navigated to
-    recipeCardComponent.openRecipe();
+    const recipeCard = rootElement.querySelector<HTMLElement>('.recipe-card');
+    recipeCard?.click();
     expect(mockRecipeService.setRecipe).toHaveBeenCalledWith(mockRecipe);
     expect(mockRouter.navigate).toHaveBeenCalledWith([
       `/recipe/${mockRecipe.id}`,

--- a/src/app/components/recipe-card/recipe-card.component.ts
+++ b/src/app/components/recipe-card/recipe-card.component.ts
@@ -28,7 +28,9 @@ export class RecipeCardComponent implements OnInit {
     );
   }
 
-  toggleFavoriteRecipe() {
+  toggleFavoriteRecipe(event: MouseEvent) {
+    // Don't trigger the card's click event
+    event.stopPropagation();
     // Placeholder for the heart button
     this.isFavorite = !this.isFavorite;
   }

--- a/src/app/components/recipe-card/recipe-card.component.ts
+++ b/src/app/components/recipe-card/recipe-card.component.ts
@@ -39,5 +39,8 @@ export class RecipeCardComponent implements OnInit {
     this.recipeService.setRecipe(this.recipe);
     console.log(this.recipe);
     this.router.navigate([`/recipe/${this.recipe.id}`]);
+    // Scroll to the top so the recipe header can be viewed
+    const sidenav = document.querySelector<HTMLElement>('.sidenav-content');
+    sidenav?.scroll(0, 0);
   }
 }

--- a/src/app/components/recipe-card/recipe-card.component.ts
+++ b/src/app/components/recipe-card/recipe-card.component.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { Router } from '@angular/router';
+
+import Recipe from 'src/app/models/recipe.model';
+import { RecipeService } from 'src/app/services/recipe.service';
+
+@Component({
+  selector: 'app-recipe-card',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatCardModule, MatIconModule],
+  templateUrl: './recipe-card.component.html',
+  styleUrl: './recipe-card.component.scss',
+})
+export class RecipeCardComponent implements OnInit {
+  @Input({ required: true }) recipe!: Recipe;
+  calories?: Recipe['nutrients'][number];
+  isFavorite = false;
+
+  constructor(private recipeService: RecipeService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.calories = this.recipe.nutrients.find(
+      (nutrient) => nutrient.name === 'Calories'
+    );
+  }
+
+  toggleFavoriteRecipe() {
+    // Placeholder for the heart button
+    this.isFavorite = !this.isFavorite;
+  }
+
+  openRecipe() {
+    this.recipeService.setRecipe(this.recipe);
+    console.log(this.recipe);
+    this.router.navigate([`/recipe/${this.recipe.id}`]);
+  }
+}

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -166,7 +166,6 @@
           class="lightbulb-icon"
           aria-hidden="true"
         />
-        >
       </mat-card-header>
       <!-- Render HTML tags -->
       <mat-card-content [innerHtml]="recipe!.summary" />

--- a/src/app/components/search/search.component.html
+++ b/src/app/components/search/search.component.html
@@ -1,3 +1,4 @@
+<!-- Search form -->
 <form class="recipe-form" [formGroup]="filterFormGroup" (ngSubmit)="onSubmit()">
   <mat-form-field class="recipe-query">
     <mat-label>Query</mat-label>
@@ -132,3 +133,11 @@
     <mat-icon fontIcon="error" />{{ Errors.noResults }}
   </p>
 </form>
+
+<!-- Results -->
+<ng-container *ngIf="recipes.length > 0">
+  <h1>Results</h1>
+  <ul *ngFor="let recipe of recipes">
+    <li><app-recipe-card [recipe]="recipe" /></li>
+  </ul>
+</ng-container>

--- a/src/app/components/search/search.component.html
+++ b/src/app/components/search/search.component.html
@@ -135,9 +135,12 @@
 </form>
 
 <!-- Results -->
-<ng-container *ngIf="recipes.length > 0">
-  <h1>Results</h1>
-  <ul *ngFor="let recipe of recipes">
-    <li><app-recipe-card [recipe]="recipe" /></li>
+<section *ngIf="recipes.length > 0">
+  <mat-divider class="results-divider" />
+  <h1 class="results-title">Results</h1>
+  <ul class="results-list">
+    <li *ngFor="let recipe of recipes">
+      <app-recipe-card [recipe]="recipe" />
+    </li>
   </ul>
-</ng-container>
+</section>

--- a/src/app/components/search/search.component.scss
+++ b/src/app/components/search/search.component.scss
@@ -78,7 +78,7 @@ $error-color: #d32f2f; // red-700
   margin: 16px;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: space-around;
   align-items: flex-start;
   gap: 16px;
 

--- a/src/app/components/search/search.component.scss
+++ b/src/app/components/search/search.component.scss
@@ -63,3 +63,27 @@ $error-color: #d32f2f; // red-700
     color: $error-color;
   }
 }
+
+.results-divider {
+  margin: 16px 16px 8px;
+}
+
+.results-title {
+  text-align: center;
+}
+
+.results-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+
+  li {
+    cursor: pointer;
+    max-width: 312px; // match the width of the images
+  }
+}

--- a/src/app/components/search/search.component.spec.ts
+++ b/src/app/components/search/search.component.spec.ts
@@ -305,6 +305,9 @@ describe('SearchComponent', () => {
       rootElement.querySelector<HTMLHeadingElement>('.results-title');
     expect(resultsTitle).not.toBeNull();
     expect(resultsTitle?.textContent).toBe('Results');
-    expect(rootElement.querySelector('.results-list')).not.toBeNull();
+    const resultsList =
+      rootElement.querySelector<HTMLUListElement>('.results-list');
+    expect(resultsList).not.toBeNull();
+    expect(resultsList?.childElementCount).toBe(mockRecipes.length);
   });
 });

--- a/src/app/components/search/search.component.spec.ts
+++ b/src/app/components/search/search.component.spec.ts
@@ -6,6 +6,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterModule } from '@angular/router';
 
 import { SearchComponent } from './search.component';
 import Constants from 'src/app/constants/constants';
@@ -18,7 +19,12 @@ describe('SearchComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SearchComponent, NoopAnimationsModule, HttpClientTestingModule],
+      imports: [
+        SearchComponent,
+        NoopAnimationsModule,
+        HttpClientTestingModule,
+        RouterModule.forRoot([]),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SearchComponent);

--- a/src/app/components/search/search.component.spec.ts
+++ b/src/app/components/search/search.component.spec.ts
@@ -9,6 +9,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SearchComponent } from './search.component';
 import Constants from 'src/app/constants/constants';
+import { mockRecipes } from 'src/app/models/recipe.mock';
 
 describe('SearchComponent', () => {
   let searchComponent: SearchComponent;
@@ -94,6 +95,7 @@ describe('SearchComponent', () => {
     expect(submitButton?.disabled).toBeFalse();
     expect(rootElement.querySelector('.progress-spinner')).toBeNull();
     expect(rootElement.querySelector('.no-results-error')).toBeNull();
+    expect(rootElement.querySelector('.results-title')).toBeNull();
   });
 
   it('should start with a valid form', () => {
@@ -255,6 +257,7 @@ describe('SearchComponent', () => {
     expect(noResultsError?.textContent).toContain(
       searchComponent.Errors.noResults
     );
+    expect(rootElement.querySelector('.results-title')).toBeNull();
   });
 
   it('should load recipes after submitting the initial form', fakeAsync(() => {
@@ -291,5 +294,17 @@ describe('SearchComponent', () => {
     expect(searchComponent.loadingMessage).toBe('');
     jasmine.clock().tick(3000);
     expect(Constants.loadingMessages).toContain(searchComponent.loadingMessage);
+  });
+
+  it('shows results if there are recipes', () => {
+    // The results section should show if there's at least one recipe
+    searchComponent.recipes = mockRecipes;
+    fixture.detectChanges();
+
+    const resultsTitle =
+      rootElement.querySelector<HTMLHeadingElement>('.results-title');
+    expect(resultsTitle).not.toBeNull();
+    expect(resultsTitle?.textContent).toBe('Results');
+    expect(rootElement.querySelector('.results-list')).not.toBeNull();
   });
 });

--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -5,8 +5,8 @@ import {
   transition,
   trigger,
 } from '@angular/animations';
-import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { CommonModule, Location } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormControl,
@@ -26,9 +26,11 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 
 import Constants from 'src/app/constants/constants';
-import { getRandomElement } from 'src/app/helpers/array';
+import { getRandomElement, toArray } from 'src/app/helpers/array';
 import RecipeFilter from 'src/app/models/recipe-filter.model';
 import Recipe, {
   CUISINES,
@@ -37,9 +39,13 @@ import Recipe, {
   MealType,
   SPICE_LEVELS,
   SpiceLevel,
+  isValidCuisine,
+  isValidMealType,
+  isValidSpiceLevel,
 } from 'src/app/models/recipe.model';
 import { RecipeService } from 'src/app/services/recipe.service';
 import { RecipeCardComponent } from '../recipe-card/recipe-card.component';
+import { isNumeric } from 'src/app/helpers/string';
 
 // Add null & undefined to all the object's values
 type PartialNull<T> = {
@@ -116,7 +122,7 @@ const calorieRangeValidator: ValidatorFn = (
     ]),
   ],
 })
-export class SearchComponent {
+export class SearchComponent implements OnInit, OnDestroy {
   filterFormNames = FilterForm;
   filterFormGroup = new FormGroup(
     {
@@ -148,6 +154,9 @@ export class SearchComponent {
     noResults: 'No recipes found',
   };
 
+  queryParamsSubscription?: Subscription;
+  valueChangeSubscription?: Subscription;
+
   isLoading = false;
   private defaultLoadingMessage = '';
   loadingMessage = this.defaultLoadingMessage;
@@ -163,8 +172,69 @@ export class SearchComponent {
 
   constructor(
     private recipeService: RecipeService,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private route: ActivatedRoute,
+    private router: Router,
+    private location: Location
   ) {}
+
+  ngOnInit(): void {
+    // Initialize the form based on the query parameters
+    this.queryParamsSubscription = this.route.queryParams.subscribe(
+      (params) => {
+        this.filterFormGroup.patchValue({
+          ...params,
+          // Parse all non-string values
+          [FilterForm.minCals]: isNumeric(params.minCals)
+            ? Number(params.minCals)
+            : null,
+          [FilterForm.maxCals]: isNumeric(params.maxCals)
+            ? Number(params.maxCals)
+            : null,
+          [FilterForm.vegetarian]: params.vegetarian === 'true',
+          [FilterForm.vegan]: params.vegan === 'true',
+          [FilterForm.glutenFree]: params.glutenFree === 'true',
+          [FilterForm.healthy]: params.healthy === 'true',
+          [FilterForm.cheap]: params.cheap === 'true',
+          [FilterForm.sustainable]: params.sustainable === 'true',
+          // 0 = undefined, 1 = string, 2+ = array
+          [FilterForm.spiceLevel]: toArray(params.spiceLevel).filter(
+            (spiceLevel): spiceLevel is SpiceLevel =>
+              isValidSpiceLevel(spiceLevel)
+          ),
+          [FilterForm.type]: toArray(params.type).filter(
+            (spiceLevel): spiceLevel is MealType => isValidMealType(spiceLevel)
+          ),
+          [FilterForm.culture]: toArray(params.culture).filter(
+            (spiceLevel): spiceLevel is Cuisine => isValidCuisine(spiceLevel)
+          ),
+        });
+      }
+    );
+
+    this.valueChangeSubscription = this.filterFormGroup.valueChanges.subscribe(
+      (filter) => {
+        // Update the query params with the selected filters
+        const urlTreePath = this.router
+          .createUrlTree([], {
+            queryParams: filter,
+          })
+          .toString();
+
+        if (this.location.path() === urlTreePath) {
+          // Don't add duplicate items to the browser's history
+          this.location.replaceState(urlTreePath);
+        } else {
+          this.location.go(urlTreePath);
+        }
+      }
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.queryParamsSubscription?.unsubscribe();
+    this.valueChangeSubscription?.unsubscribe();
+  }
 
   onSubmit() {
     const recipeFilter = this.removeNullValues(this.filterFormGroup.value);

--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -38,6 +38,7 @@ import Recipe, {
   SpiceLevel,
 } from 'src/app/models/recipe.model';
 import { RecipeService } from 'src/app/services/recipe.service';
+import { RecipeCardComponent } from '../recipe-card/recipe-card.component';
 
 // Add null & undefined to all the object's values
 type PartialNull<T> = {
@@ -88,6 +89,7 @@ const calorieRangeValidator: ValidatorFn = (
     MatOptionModule,
     MatProgressSpinnerModule,
     MatSelectModule,
+    RecipeCardComponent,
   ],
   templateUrl: './search.component.html',
   styleUrl: './search.component.scss',
@@ -148,6 +150,7 @@ export class SearchComponent {
   private defaultLoadingMessage = '';
   loadingMessage = this.defaultLoadingMessage;
   noRecipesFound = false;
+  recipes: Recipe[] = [];
 
   // Exclude unknown cases and sort for ease of reference
   readonly spiceLevels = SPICE_LEVELS.filter(
@@ -171,7 +174,7 @@ export class SearchComponent {
       next: (recipes: Recipe[]) => {
         this.isLoading = false;
         clearInterval(timer);
-        console.log('Found recipes:', recipes);
+        this.recipes = recipes;
         this.noRecipesFound = recipes.length === 0;
       },
       error: (error: Error) => {

--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -19,6 +19,7 @@ import {
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatOptionModule } from '@angular/material/core';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -83,6 +84,7 @@ const calorieRangeValidator: ValidatorFn = (
     ReactiveFormsModule,
     MatButtonModule,
     MatCheckboxModule,
+    MatDividerModule,
     MatFormFieldModule,
     MatInputModule,
     MatIconModule,
@@ -166,7 +168,6 @@ export class SearchComponent {
 
   onSubmit() {
     const recipeFilter = this.removeNullValues(this.filterFormGroup.value);
-    console.log('Submitted recipe filter:', recipeFilter);
     this.isLoading = true;
     const timer = this.showLoadingMessages();
 

--- a/src/app/helpers/array.spec.ts
+++ b/src/app/helpers/array.spec.ts
@@ -1,4 +1,4 @@
-import { getRandomElement } from './array';
+import { getRandomElement, toArray } from './array';
 
 describe('getRandomElement', () => {
   it('returns an element in the array', () => {
@@ -30,5 +30,19 @@ describe('getRandomElement', () => {
     expect(() => getRandomElement(emptyArray)).toThrowError(
       'The array must contain at least one element to be randomly selected.'
     );
+  });
+});
+
+describe('toArray', () => {
+  it('should convert undefined to an empty array', () => {
+    expect(toArray()).toEqual([]);
+  });
+
+  it('should convert a string to an array', () => {
+    expect(toArray('foo')).toEqual(['foo']);
+  });
+
+  it('should return an array as-is', () => {
+    expect(toArray(['foo', 'bar'])).toEqual(['foo', 'bar']);
   });
 });

--- a/src/app/helpers/array.ts
+++ b/src/app/helpers/array.ts
@@ -15,3 +15,11 @@ export const getRandomElement = <T>(array: Array<T>): T => {
 
   return array[Math.floor(Math.random() * array.length)];
 };
+
+/**
+ * Convert the input to an array
+ * @param input a string, an array of strings, or undefined
+ * @returns an empty array if undefined, a one-element array if a string, or the array itself
+ */
+export const toArray = (input?: string | string[]) =>
+  input === undefined ? [] : Array.isArray(input) ? input : [input];

--- a/src/app/helpers/string.test.ts
+++ b/src/app/helpers/string.test.ts
@@ -1,0 +1,47 @@
+import { isNumeric } from './string';
+
+describe('isNumeric', () => {
+  it('passes all positive cases', () => {
+    // Given a set of inputs that resemble numbers
+    [
+      0,
+      1,
+      1234567890,
+      '1234567890',
+      '0',
+      '1',
+      '1.1',
+      '-1',
+      '-1.2354',
+      '-1234567890',
+      -1,
+      -32.1,
+      '0x1',
+    ].forEach((num) => {
+      // When passed to isNumeric
+      // Then they should all return true
+      expect(isNumeric(num)).toBe(true);
+    });
+  });
+
+  it('passes all negative cases', () => {
+    // Given a set of inputs that don't resemble numbers
+    [
+      true,
+      false,
+      '1..1',
+      '1,1',
+      '-32.1.12',
+      '',
+      '   ',
+      null,
+      undefined,
+      [],
+      NaN,
+    ].forEach((num) => {
+      // When passed to isNumeric
+      // Then they should all return false
+      expect(isNumeric(num as string | number)).toBe(false);
+    });
+  });
+});

--- a/src/app/helpers/string.ts
+++ b/src/app/helpers/string.ts
@@ -1,0 +1,12 @@
+// Helper methods for strings
+
+/**
+ * Check if the input is a number or a string that can be parsed as a number
+ *
+ * Source: https://stackoverflow.com/a/58550111
+ * @param num the number or string to check
+ * @returns true if `num` can be parsed as a number, false otherwise
+ */
+export const isNumeric = (num: number | string): boolean =>
+  (typeof num === "number" || (typeof num === "string" && num.trim() !== "")) &&
+  !isNaN(num as number);


### PR DESCRIPTION
<img src="https://github.com/Abhiek187/ez-recipes-web/assets/29958092/afadec3f-575e-4466-bf5a-50a20ec940e9" alt="search-ipad" width="600">

Closes #8 & closes #205

Like with the other platforms, creating the recipe cards didn't take nearly as long as creating the filter form. As a bonus, I updated the query parameters to match the filter form's inputs so users can save their progress. I imagine a scenario where (since they can't right-click the cards), they click a card, aren't interested in a recipe, and want to go back. I did plenty of validation checks to make sure invalid query parameters were ignored. And I decided to lazy-load the search page anyway.

The last thing I need to do is update the docs to reflect this change, update the screenshots, and anything else I had to do in the mobile apps.