### PR TITLE
Profile Pt 1: APIs

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -29,6 +29,14 @@ export const routes: Record<string, Route> = {
         (mod) => mod.GlossaryComponent
       ),
   },
+  profile: {
+    path: 'profile',
+    title: 'Profile',
+    loadComponent: () =>
+      import('./components/profile/profile.component').then(
+        (mod) => mod.ProfileComponent
+      ),
+  },
   // The default route should be listed between the static routes and wildcard routes
   home: { path: '', title: 'Home', component: HomeComponent },
   // Show a 404 page for any other route
@@ -42,7 +50,6 @@ export const routes: Record<string, Route> = {
 @Injectable({ providedIn: 'root' })
 export class TemplatePageTitleStrategy extends TitleStrategy {
   private readonly title = inject(Title);
-
 
   override updateTitle(routerState: RouterStateSnapshot) {
     // Prepend the title for each page with the app name

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -20,14 +20,14 @@ import Constants from 'src/app/constants/constants';
 import { RecipeService } from 'src/app/services/recipe.service';
 import { mockRecipes } from 'src/app/models/recipe.mock';
 import { mockTime } from 'src/app/models/term-store.mock';
-import { RecipeWithTimestamp } from 'src/app/models/recipe.model';
+import { RecentRecipe } from 'src/app/models/recipe.model';
 
 describe('HomeComponent', () => {
   let homeComponent: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
   let rootElement: HTMLElement;
 
-  const mockRecentRecipes = (value: RecipeWithTimestamp[]) => {
+  const mockRecentRecipes = (value: RecentRecipe[]) => {
     spyOn(RecipeService.prototype, 'getRecentRecipes').and.returnValue(
       new Observable((subscriber) => {
         subscriber.next(value);

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -131,7 +131,11 @@ describe('HomeComponent', () => {
 
   it('should show the recents section if there are recent recipes', () => {
     mockRecentRecipes(
-      mockRecipes.map((recipe) => ({ ...recipe, timestamp: mockTime }))
+      mockRecipes.map((recipe) => ({
+        ...recipe,
+        timestamp: mockTime,
+        isFavorite: false,
+      }))
     );
 
     const recentsSection =

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -13,6 +13,7 @@ import { Subscription } from 'rxjs';
 
 import { RecipeComponent } from '../recipe/recipe.component';
 import { routes } from 'src/app/app-routing.module';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-navbar',
@@ -35,7 +36,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   isSmallScreen: boolean;
   // Navigation links to show in the sidenav
-  navItems = [routes.home, routes.search, routes.glossary, routes.profile];
+  navItems = environment.production
+    ? [routes.home, routes.search, routes.glossary]
+    : [routes.home, routes.search, routes.glossary, routes.profile];
 
   isRecipePage = false;
   isFavorite = false;

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -35,7 +35,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   isSmallScreen: boolean;
   // Navigation links to show in the sidenav
-  navItems = [routes.home, routes.search, routes.glossary];
+  navItems = [routes.home, routes.search, routes.glossary, routes.profile];
 
   isRecipePage = false;
   isFavorite = false;

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -1,0 +1,1 @@
+<p>profile works!</p>

--- a/src/app/components/profile/profile.component.spec.ts
+++ b/src/app/components/profile/profile.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProfileComponent } from './profile.component';
+
+describe('ProfileComponent', () => {
+  let component: ProfileComponent;
+  let fixture: ComponentFixture<ProfileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-profile',
+  imports: [],
+  templateUrl: './profile.component.html',
+  styleUrl: './profile.component.scss'
+})
+export class ProfileComponent {
+
+}

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -29,7 +29,8 @@ abstract class Constants {
 
   // IndexedDB
   static recentRecipesDB = {
-    name: 'RecentRecipesDB',
+    dbName: 'RecentRecipesDB',
+    tableName: 'recipes',
     max: 10,
     config: [
       {

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -1,3 +1,5 @@
+import { RecentRecipe } from '../models/recipe.model';
+
 abstract class Constants {
   static readonly loadingMessages = [
     'Prepping the ingredients... 🍱',
@@ -19,6 +21,7 @@ abstract class Constants {
   // APIs
   static readonly recipesPath = '/api/recipes';
   static readonly termsPath = '/api/terms';
+  static readonly chefsPath = '/api/chefs';
 
   static LocalStorage = class {
     static readonly terms = 'terms';
@@ -27,13 +30,28 @@ abstract class Constants {
   // IndexedDB
   static recentRecipesDB = {
     name: 'RecentRecipesDB',
-    version: 1,
     max: 10,
-    // Primary key and indexes
-    indexes: {
-      id: 'id',
-      timestamp: 'timestamp',
-    },
+    config: [
+      {
+        version: 1,
+        // Primary key and indexes
+        indexes: {
+          id: 'id',
+          timestamp: 'timestamp',
+        },
+      },
+      {
+        version: 2,
+        indexes: {
+          id: 'id',
+          timestamp: 'timestamp',
+          isFavorite: 'isFavorite',
+        },
+        upgrade: (recentRecipe: RecentRecipe) => {
+          recentRecipe.isFavorite = false;
+        },
+      },
+    ],
   };
 }
 

--- a/src/app/helpers/recent-recipes-db.ts
+++ b/src/app/helpers/recent-recipes-db.ts
@@ -1,18 +1,25 @@
 import Dexie, { Table } from 'dexie';
 
-import { RecipeWithTimestamp } from '../models/recipe.model';
+import { RecentRecipe } from '../models/recipe.model';
 import Constants from '../constants/constants';
 
 class RecentRecipesDB extends Dexie {
-  recipes!: Table<RecipeWithTimestamp, number>;
+  recipes!: Table<RecentRecipe, number>;
 
   constructor() {
-    const { name, version, indexes } = Constants.recentRecipesDB;
+    const { name, config } = Constants.recentRecipesDB;
     super(name);
 
-    this.version(version).stores({
-      recipes: Object.values(indexes).join(', '),
-    });
+    for (const { version, indexes, upgrade } of config) {
+      this.version(version).stores({
+        recipes: Object.values(indexes).join(', '),
+      });
+      if (upgrade !== undefined) {
+        this.version(version).upgrade((tx) =>
+          tx.table<RecentRecipe>(name).toCollection().modify(upgrade)
+        );
+      }
+    }
     // No need to populate since recipes will stay in memory for now
   }
 }

--- a/src/app/helpers/recent-recipes-db.ts
+++ b/src/app/helpers/recent-recipes-db.ts
@@ -7,16 +7,16 @@ class RecentRecipesDB extends Dexie {
   recipes!: Table<RecentRecipe, number>;
 
   constructor() {
-    const { name, config } = Constants.recentRecipesDB;
-    super(name);
+    const { dbName, tableName, config } = Constants.recentRecipesDB;
+    super(dbName);
 
     for (const { version, indexes, upgrade } of config) {
       this.version(version).stores({
-        recipes: Object.values(indexes).join(', '),
+        [tableName]: Object.values(indexes).join(', '),
       });
       if (upgrade !== undefined) {
         this.version(version).upgrade((tx) =>
-          tx.table<RecentRecipe>(name).toCollection().modify(upgrade)
+          tx.table<RecentRecipe>(tableName).toCollection().modify(upgrade)
         );
       }
     }

--- a/src/app/models/profile.mock.ts
+++ b/src/app/models/profile.mock.ts
@@ -1,4 +1,5 @@
-import { Chef } from './profile.model';
+import { Chef, ChefEmailResponse, LoginResponse } from './profile.model';
+import { Token } from './recipe.model';
 
 export const mockChef: Chef = {
   uid: 'oJG5PZ8KIIfvQMDsQzOwDbu2m6O2',
@@ -11,4 +12,16 @@ export const mockChef: Chef = {
   },
   favoriteRecipes: ['641024'],
   token: 'e30.e30.e30',
+};
+
+export const mockLoginResponse = (emailVerified = true): LoginResponse => ({
+  uid: mockChef.uid,
+  token: mockChef.token,
+  emailVerified,
+});
+
+export const mockChefEmailResponse: ChefEmailResponse = {
+  kind: 'identitytoolkit#GetOobConfirmationCodeResponse',
+  email: mockChef.email,
+  token: mockChef.token,
 };

--- a/src/app/models/profile.mock.ts
+++ b/src/app/models/profile.mock.ts
@@ -1,5 +1,4 @@
 import { Chef, ChefEmailResponse, LoginResponse } from './profile.model';
-import { Token } from './recipe.model';
 
 export const mockChef: Chef = {
   uid: 'oJG5PZ8KIIfvQMDsQzOwDbu2m6O2',

--- a/src/app/models/profile.mock.ts
+++ b/src/app/models/profile.mock.ts
@@ -1,0 +1,14 @@
+import { Chef } from './profile.model';
+
+export const mockChef: Chef = {
+  uid: 'oJG5PZ8KIIfvQMDsQzOwDbu2m6O2',
+  email: 'test@email.com',
+  emailVerified: true,
+  ratings: { '641024': 5, '663849': 3 },
+  recentRecipes: {
+    '641024': '2024-10-17T02:54:07.471Z',
+    '663849': '2024-10-17T22:28:27.387Z',
+  },
+  favoriteRecipes: ['641024'],
+  token: 'e30.e30.e30',
+};

--- a/src/app/models/profile.model.ts
+++ b/src/app/models/profile.model.ts
@@ -1,0 +1,49 @@
+export enum AuthState {
+  Unauthenticated,
+  Authenticated,
+  Loading,
+}
+
+export type Chef = {
+  uid: string;
+  email: string;
+  emailVerified: boolean;
+  ratings: Record<string, number>;
+  recentRecipes: Record<string, string>;
+  favoriteRecipes: string[];
+  token: string;
+};
+
+export type ChefEmailResponse = {
+  kind: string;
+  email: string;
+  token?: string;
+};
+
+export type ChefUpdate = {
+  type: ChefUpdateType;
+  email: string;
+  password?: string;
+};
+
+export enum ChefUpdateType {
+  Email = 'email',
+  Password = 'password',
+}
+
+export type LoginCredentials = {
+  email: string;
+  password: string;
+};
+
+export type LoginResponse = {
+  uid: string;
+  token: string;
+  emailVerified: boolean;
+};
+
+export enum ProfileAction {
+  VerifyEmail = 'verifyEmail',
+  ChangeEmail = 'changeEmail',
+  ResetPassword = 'resetPassword',
+}

--- a/src/app/models/recipe-filter.model.ts
+++ b/src/app/models/recipe-filter.model.ts
@@ -10,6 +10,7 @@ type RecipeFilter = {
   healthy?: boolean;
   cheap?: boolean;
   sustainable?: boolean;
+  rating?: number;
   spiceLevel?: SpiceLevel[];
   type?: MealType[];
   culture?: Cuisine[];

--- a/src/app/models/recipe.mock.ts
+++ b/src/app/models/recipe.mock.ts
@@ -1,4 +1,5 @@
-import Recipe from './recipe.model';
+import { mockChef } from './profile.mock';
+import Recipe, { Token } from './recipe.model';
 
 // Abstract classes can hold static properties to group the mock recipes together
 abstract class MockRecipes {
@@ -1319,3 +1320,7 @@ export const mockRecipes = [
   MockRecipes.jambalayaStew,
   MockRecipes.chocolateCupcake,
 ];
+
+export const mockToken: Token = {
+  token: mockChef.token,
+};

--- a/src/app/models/recipe.mock.ts
+++ b/src/app/models/recipe.mock.ts
@@ -310,6 +310,9 @@ abstract class MockRecipes {
         ],
       },
     ],
+    totalRatings: 2,
+    averageRating: 4.5,
+    views: 10,
   };
 
   /**
@@ -853,6 +856,9 @@ abstract class MockRecipes {
         ],
       },
     ],
+    totalRatings: 538,
+    averageRating: 4.714,
+    views: 1804,
   };
 
   /**
@@ -1300,6 +1306,9 @@ abstract class MockRecipes {
         ],
       },
     ],
+    totalRatings: 3,
+    averageRating: 3.5,
+    views: 25,
   };
 }
 

--- a/src/app/models/recipe.model.ts
+++ b/src/app/models/recipe.model.ts
@@ -137,10 +137,24 @@ type Recipe = {
     }[];
   }[];
   token?: string; // searchSequenceToken for pagination
+  totalRatings?: number;
+  averageRating?: number;
+  views?: number;
 };
 
 export default Recipe;
 
-export interface RecipeWithTimestamp extends Recipe {
+export interface RecentRecipe extends Recipe {
   timestamp: number;
+  isFavorite: boolean;
 }
+
+export type RecipeUpdate = {
+  rating?: number;
+  view?: boolean;
+  isFavorite?: boolean;
+};
+
+export type Token = {
+  token?: string;
+};

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -10,9 +10,18 @@ import { TestBed } from '@angular/core/testing';
 import { firstValueFrom } from 'rxjs';
 
 import { ChefService } from './chef.service';
-import { mockChef } from '../models/profile.mock';
+import {
+  mockChef,
+  mockChefEmailResponse,
+  mockLoginResponse,
+} from '../models/profile.mock';
 import Constants from '../constants/constants';
 import { environment } from 'src/environments/environment';
+import {
+  ChefUpdate,
+  ChefUpdateType,
+  LoginCredentials,
+} from '../models/profile.model';
 
 describe('ChefService', () => {
   let chefService: ChefService;
@@ -20,7 +29,8 @@ describe('ChefService', () => {
 
   const baseUrl = `${environment.serverBaseUrl}${Constants.chefsPath}`;
   const mockError = new ProgressEvent('error');
-  const mockErrorMessage = `Http failure response for ${baseUrl}: 0 `;
+  const mockErrorMessage = (url: string) =>
+    `Http failure response for ${url}: 0 `;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -67,6 +77,228 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
+    await expectAsync(chefPromise).toBeRejectedWithError(
+      mockErrorMessage(baseUrl)
+    );
+  });
+
+  it('should create a chef', async () => {
+    const credentials: LoginCredentials = {
+      email: mockChef.email,
+      password: 'password',
+    };
+    const chefPromise = firstValueFrom(chefService.createChef(credentials));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: baseUrl,
+    });
+    expect(req.request.headers.get('Authorization')).toBeNull();
+    expect(req.request.body).toBe(credentials);
+    req.flush(mockLoginResponse());
+
+    await expectAsync(chefPromise).toBeResolvedTo(mockLoginResponse());
+  });
+
+  it('should return an error if the POST chef API fails', async () => {
+    const credentials: LoginCredentials = {
+      email: mockChef.email,
+      password: 'password',
+    };
+    const chefPromise = firstValueFrom(chefService.createChef(credentials));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: baseUrl,
+    });
+    req.error(mockError);
+
+    await expectAsync(chefPromise).toBeRejectedWithError(
+      mockErrorMessage(baseUrl)
+    );
+  });
+
+  it('should update a chef', async () => {
+    const fields: ChefUpdate = {
+      type: ChefUpdateType.Password,
+      email: mockChef.email,
+      password: 'newpassword',
+    };
+    const chefPromise = firstValueFrom(
+      chefService.updateChef(fields, mockChef.token)
+    );
+
+    const req = httpTestingController.expectOne({
+      method: 'PATCH',
+      url: baseUrl,
+    });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
+    expect(req.request.body).toBe(fields);
+    req.flush(mockChefEmailResponse);
+
+    await expectAsync(chefPromise).toBeResolvedTo(mockChefEmailResponse);
+  });
+
+  it('should update a chef without a token', async () => {
+    const fields: ChefUpdate = {
+      type: ChefUpdateType.Email,
+      email: mockChef.email,
+    };
+    const chefPromise = firstValueFrom(chefService.updateChef(fields));
+
+    const req = httpTestingController.expectOne({
+      method: 'PATCH',
+      url: baseUrl,
+    });
+    expect(req.request.headers.get('Authorization')).toBeNull();
+    expect(req.request.body).toBe(fields);
+    req.flush(mockChefEmailResponse);
+
+    await expectAsync(chefPromise).toBeResolvedTo(mockChefEmailResponse);
+  });
+
+  it('should return an error if the PATCH chef API fails', async () => {
+    const fields: ChefUpdate = {
+      type: ChefUpdateType.Email,
+      email: mockChef.email,
+    };
+    const chefPromise = firstValueFrom(chefService.updateChef(fields));
+
+    const req = httpTestingController.expectOne({
+      method: 'PATCH',
+      url: baseUrl,
+    });
+    req.error(mockError);
+
+    await expectAsync(chefPromise).toBeRejectedWithError(
+      mockErrorMessage(baseUrl)
+    );
+  });
+
+  it('should delete a chef', async () => {
+    const chefPromise = firstValueFrom(chefService.deleteChef(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'DELETE',
+      url: baseUrl,
+    });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
+    req.flush(null);
+
+    await expectAsync(chefPromise).toBeResolvedTo(null);
+  });
+
+  it('should return an error if the DELETE chef API fails', async () => {
+    const chefPromise = firstValueFrom(chefService.deleteChef(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'DELETE',
+      url: baseUrl,
+    });
+    req.error(mockError);
+
+    await expectAsync(chefPromise).toBeRejectedWithError(
+      mockErrorMessage(baseUrl)
+    );
+  });
+
+  it('should verify an email', async () => {
+    const chefPromise = firstValueFrom(chefService.verifyEmail(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${baseUrl}/verify`,
+    });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
+    expect(req.request.body).toBeNull();
+    req.flush(mockChefEmailResponse);
+
+    await expectAsync(chefPromise).toBeResolvedTo(mockChefEmailResponse);
+  });
+
+  it('should return an error if the verify email API fails', async () => {
+    const chefPromise = firstValueFrom(chefService.verifyEmail(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${baseUrl}/verify`,
+    });
+    req.error(mockError);
+
+    await expectAsync(chefPromise).toBeRejectedWithError(
+      mockErrorMessage(`${baseUrl}/verify`)
+    );
+  });
+
+  it('should login', async () => {
+    const credentials: LoginCredentials = {
+      email: mockChef.email,
+      password: 'password',
+    };
+    const chefPromise = firstValueFrom(chefService.login(credentials));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${baseUrl}/login`,
+    });
+    expect(req.request.headers.get('Authorization')).toBeNull();
+    expect(req.request.body).toBe(credentials);
+    req.flush(mockLoginResponse());
+
+    await expectAsync(chefPromise).toBeResolvedTo(mockLoginResponse());
+  });
+
+  it('should return an error if the login API fails', async () => {
+    const credentials: LoginCredentials = {
+      email: mockChef.email,
+      password: 'password',
+    };
+    const chefPromise = firstValueFrom(chefService.login(credentials));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${baseUrl}/login`,
+    });
+    req.error(mockError);
+
+    await expectAsync(chefPromise).toBeRejectedWithError(
+      mockErrorMessage(`${baseUrl}/login`)
+    );
+  });
+
+  it('should logout', async () => {
+    const chefPromise = firstValueFrom(chefService.logout(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${baseUrl}/logout`,
+    });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
+    expect(req.request.body).toBeNull();
+    req.flush(null);
+
+    await expectAsync(chefPromise).toBeResolvedTo(null);
+  });
+
+  it('should return an error if the logout API fails', async () => {
+    const chefPromise = firstValueFrom(chefService.logout(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${baseUrl}/logout`,
+    });
+    req.error(mockError);
+
+    await expectAsync(chefPromise).toBeRejectedWithError(
+      mockErrorMessage(`${baseUrl}/logout`)
+    );
   });
 });

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -1,0 +1,40 @@
+import {
+  HttpClient,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ChefService } from './chef.service';
+
+describe('ChefService', () => {
+  let chefService: ChefService;
+  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    chefService = TestBed.inject(ChefService);
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should be created', () => {
+    expect(chefService).toBeTruthy();
+  });
+});

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -1,5 +1,4 @@
 import {
-  HttpClient,
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
@@ -8,13 +7,20 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
 
 import { ChefService } from './chef.service';
+import { mockChef } from '../models/profile.mock';
+import Constants from '../constants/constants';
+import { environment } from 'src/environments/environment';
 
 describe('ChefService', () => {
   let chefService: ChefService;
-  let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
+
+  const baseUrl = `${environment.serverBaseUrl}${Constants.chefsPath}`;
+  const mockError = new ProgressEvent('error');
+  const mockErrorMessage = `Http failure response for ${baseUrl}: 0 `;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -26,7 +32,6 @@ describe('ChefService', () => {
     });
 
     chefService = TestBed.inject(ChefService);
-    httpClient = TestBed.inject(HttpClient);
     httpTestingController = TestBed.inject(HttpTestingController);
   });
 
@@ -36,5 +41,32 @@ describe('ChefService', () => {
 
   it('should be created', () => {
     expect(chefService).toBeTruthy();
+  });
+
+  it('should get a chef', async () => {
+    const chefPromise = firstValueFrom(chefService.getChef(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: baseUrl,
+    });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
+    req.flush(mockChef);
+
+    await expectAsync(chefPromise).toBeResolvedTo(mockChef);
+  });
+
+  it('should return an error if the GET chef API fails', async () => {
+    const chefPromise = firstValueFrom(chefService.getChef(mockChef.token));
+
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: baseUrl,
+    });
+    req.error(mockError);
+
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 });

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -1,0 +1,158 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { catchError, Observable, throwError } from 'rxjs';
+
+import {
+  Chef,
+  ChefEmailResponse,
+  ChefUpdate,
+  LoginCredentials,
+  LoginResponse,
+} from '../models/profile.model';
+import { environment } from 'src/environments/environment';
+import Constants from '../constants/constants';
+import {
+  mockChef,
+  mockChefEmailResponse,
+  mockLoginResponse,
+} from '../models/profile.mock';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ChefService {
+  private http = inject(HttpClient);
+  private readonly isMocking = !environment.production && environment.mock;
+
+  // API methods
+  getChef(token: string): Observable<Chef> {
+    if (this.isMocking) {
+      return this.getMockChef();
+    }
+
+    return this.http
+      .get<Chef>(`${environment.serverBaseUrl}/${Constants.chefsPath}`, {
+        headers: this.authHeader(token),
+      })
+      .pipe(catchError(this.handleError.bind(this)));
+  }
+
+  createChef(credentials: LoginCredentials): Observable<LoginResponse> {
+    if (this.isMocking) {
+      return this.getMockLoginResponse();
+    }
+
+    return this.http
+      .post<LoginResponse>(
+        `${environment.serverBaseUrl}/${Constants.chefsPath}`,
+        credentials
+      )
+      .pipe(catchError(this.handleError.bind(this)));
+  }
+
+  updateChef(
+    fields: ChefUpdate,
+    token?: string
+  ): Observable<ChefEmailResponse> {
+    if (this.isMocking) {
+      return this.getMockChefEmailResponse();
+    }
+
+    return this.http.patch<ChefEmailResponse>(
+      `${environment.serverBaseUrl}/${Constants.chefsPath}`,
+      fields,
+      {
+        headers: {
+          ...(token !== undefined && this.authHeader(token)),
+        },
+      }
+    );
+  }
+
+  deleteChef(token: string): Observable<void> {
+    if (this.isMocking) {
+      return new Observable((subscriber) => {
+        subscriber.next();
+      });
+    }
+
+    return this.http.delete<void>(
+      `${environment.serverBaseUrl}/${Constants.chefsPath}`,
+      {
+        headers: this.authHeader(token),
+      }
+    );
+  }
+
+  verifyEmail(token: string): Observable<ChefEmailResponse> {
+    if (this.isMocking) {
+      return this.getMockChefEmailResponse();
+    }
+
+    return this.http.post<ChefEmailResponse>(
+      `${environment.serverBaseUrl}/${Constants.chefsPath}/verify`,
+      null, // no body
+      { headers: this.authHeader(token) }
+    );
+  }
+
+  login(credentials: LoginCredentials): Observable<LoginResponse> {
+    if (this.isMocking) {
+      return this.getMockLoginResponse();
+    }
+
+    return this.http
+      .post<LoginResponse>(
+        `${environment.serverBaseUrl}/${Constants.chefsPath}/login`,
+        credentials
+      )
+      .pipe(catchError(this.handleError.bind(this)));
+  }
+
+  logout(token: string): Observable<void> {
+    if (this.isMocking) {
+      return new Observable((subscriber) => {
+        subscriber.next();
+      });
+    }
+
+    return this.http.post<void>(
+      `${environment.serverBaseUrl}/${Constants.chefsPath}/logout`,
+      null,
+      {
+        headers: this.authHeader(token),
+      }
+    );
+  }
+
+  // Mocks
+  getMockChef(): Observable<Chef> {
+    return new Observable((subscriber) => {
+      subscriber.next(mockChef);
+    });
+  }
+
+  getMockLoginResponse(emailVerified = true): Observable<LoginResponse> {
+    return new Observable((subscriber) => {
+      subscriber.next(mockLoginResponse(emailVerified));
+    });
+  }
+
+  getMockChefEmailResponse(): Observable<ChefEmailResponse> {
+    return new Observable((subscriber) => {
+      subscriber.next(mockChefEmailResponse);
+    });
+  }
+
+  // Helpers
+  private handleError(error: HttpErrorResponse): Observable<never> {
+    console.error(error);
+    return throwError(() => new Error(error.message));
+  }
+
+  private authHeader(token: string) {
+    return {
+      Authorization: `Bearer ${token}`,
+    };
+  }
+}

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -31,7 +31,7 @@ export class ChefService {
     }
 
     return this.http
-      .get<Chef>(`${environment.serverBaseUrl}/${Constants.chefsPath}`, {
+      .get<Chef>(`${environment.serverBaseUrl}${Constants.chefsPath}`, {
         headers: this.authHeader(token),
       })
       .pipe(catchError(this.handleError.bind(this)));
@@ -44,7 +44,7 @@ export class ChefService {
 
     return this.http
       .post<LoginResponse>(
-        `${environment.serverBaseUrl}/${Constants.chefsPath}`,
+        `${environment.serverBaseUrl}${Constants.chefsPath}`,
         credentials
       )
       .pipe(catchError(this.handleError.bind(this)));
@@ -59,7 +59,7 @@ export class ChefService {
     }
 
     return this.http.patch<ChefEmailResponse>(
-      `${environment.serverBaseUrl}/${Constants.chefsPath}`,
+      `${environment.serverBaseUrl}${Constants.chefsPath}`,
       fields,
       {
         headers: {
@@ -77,7 +77,7 @@ export class ChefService {
     }
 
     return this.http.delete<void>(
-      `${environment.serverBaseUrl}/${Constants.chefsPath}`,
+      `${environment.serverBaseUrl}${Constants.chefsPath}`,
       {
         headers: this.authHeader(token),
       }
@@ -90,7 +90,7 @@ export class ChefService {
     }
 
     return this.http.post<ChefEmailResponse>(
-      `${environment.serverBaseUrl}/${Constants.chefsPath}/verify`,
+      `${environment.serverBaseUrl}${Constants.chefsPath}/verify`,
       null, // no body
       { headers: this.authHeader(token) }
     );
@@ -103,7 +103,7 @@ export class ChefService {
 
     return this.http
       .post<LoginResponse>(
-        `${environment.serverBaseUrl}/${Constants.chefsPath}/login`,
+        `${environment.serverBaseUrl}${Constants.chefsPath}/login`,
         credentials
       )
       .pipe(catchError(this.handleError.bind(this)));
@@ -117,7 +117,7 @@ export class ChefService {
     }
 
     return this.http.post<void>(
-      `${environment.serverBaseUrl}/${Constants.chefsPath}/logout`,
+      `${environment.serverBaseUrl}${Constants.chefsPath}/logout`,
       null,
       {
         headers: this.authHeader(token),

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -58,30 +58,31 @@ export class ChefService {
       return this.getMockChefEmailResponse();
     }
 
-    return this.http.patch<ChefEmailResponse>(
-      `${environment.serverBaseUrl}${Constants.chefsPath}`,
-      fields,
-      {
-        headers: {
-          ...(token !== undefined && this.authHeader(token)),
-        },
-      }
-    );
+    return this.http
+      .patch<ChefEmailResponse>(
+        `${environment.serverBaseUrl}${Constants.chefsPath}`,
+        fields,
+        {
+          headers: {
+            ...(token !== undefined && this.authHeader(token)),
+          },
+        }
+      )
+      .pipe(catchError(this.handleError.bind(this)));
   }
 
-  deleteChef(token: string): Observable<void> {
+  deleteChef(token: string): Observable<null> {
     if (this.isMocking) {
       return new Observable((subscriber) => {
-        subscriber.next();
+        subscriber.next(null);
       });
     }
 
-    return this.http.delete<void>(
-      `${environment.serverBaseUrl}${Constants.chefsPath}`,
-      {
+    return this.http
+      .delete<null>(`${environment.serverBaseUrl}${Constants.chefsPath}`, {
         headers: this.authHeader(token),
-      }
-    );
+      })
+      .pipe(catchError(this.handleError.bind(this)));
   }
 
   verifyEmail(token: string): Observable<ChefEmailResponse> {
@@ -89,11 +90,13 @@ export class ChefService {
       return this.getMockChefEmailResponse();
     }
 
-    return this.http.post<ChefEmailResponse>(
-      `${environment.serverBaseUrl}${Constants.chefsPath}/verify`,
-      null, // no body
-      { headers: this.authHeader(token) }
-    );
+    return this.http
+      .post<ChefEmailResponse>(
+        `${environment.serverBaseUrl}${Constants.chefsPath}/verify`,
+        null, // no body
+        { headers: this.authHeader(token) }
+      )
+      .pipe(catchError(this.handleError.bind(this)));
   }
 
   login(credentials: LoginCredentials): Observable<LoginResponse> {
@@ -109,20 +112,22 @@ export class ChefService {
       .pipe(catchError(this.handleError.bind(this)));
   }
 
-  logout(token: string): Observable<void> {
+  logout(token: string): Observable<null> {
     if (this.isMocking) {
       return new Observable((subscriber) => {
-        subscriber.next();
+        subscriber.next(null);
       });
     }
 
-    return this.http.post<void>(
-      `${environment.serverBaseUrl}${Constants.chefsPath}/logout`,
-      null,
-      {
-        headers: this.authHeader(token),
-      }
-    );
+    return this.http
+      .post<null>(
+        `${environment.serverBaseUrl}${Constants.chefsPath}/logout`,
+        null,
+        {
+          headers: this.authHeader(token),
+        }
+      )
+      .pipe(catchError(this.handleError.bind(this)));
   }
 
   // Mocks

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -219,6 +219,27 @@ describe('RecipeService', () => {
     await expectAsync(recipePromise).toBeResolvedTo(mockToken);
   });
 
+  it('should update a recipe without a token', async () => {
+    // Check that updateRecipe returns a mock token even without a token
+    const id = 0;
+    const fields: RecipeUpdate = {
+      view: true,
+    };
+    const recipePromise = firstValueFrom(
+      recipeService.updateRecipe(id, fields)
+    );
+
+    const req = httpTestingController.expectOne({
+      method: 'PATCH',
+      url: `${baseUrl}/${id}`,
+    });
+    expect(req.request.headers.get('Authorization')).toBeNull();
+    expect(req.request.body).toBe(fields);
+    req.flush({});
+
+    await expectAsync(recipePromise).toBeResolvedTo({});
+  });
+
   it('should return an error if the update recipe API fails', async () => {
     // Check that updateRecipe returns an error if the request failed
     const id = 0;

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -35,6 +35,8 @@ describe('RecipeService', () => {
       isFavorite: false,
     })
   );
+  const mockError = new ProgressEvent('error');
+  const failTest = () => fail('should have failed with the network error');
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -94,10 +96,9 @@ describe('RecipeService', () => {
     // Create mock ProgressEvent with type `error`, raised when something goes wrong
     // at network level. e.g. Connection timeout, DNS error, offline, etc.
     const testUrl = `${Constants.recipesPath}/random`;
-    const mockError = new ProgressEvent('error');
 
     httpClient.get<Recipe>(testUrl).subscribe({
-      next: () => fail('should have failed with the network error'),
+      next: () => failTest(),
       error: (error: HttpErrorResponse) => {
         expect(error.error).toBe(mockError);
       },
@@ -127,10 +128,9 @@ describe('RecipeService', () => {
     // Check that getRandomRecipe returns an error if the request failed
     const id = 0;
     const testUrl = `${Constants.recipesPath}/${id}`;
-    const mockError = new ProgressEvent('error');
 
     httpClient.get<Recipe>(testUrl).subscribe({
-      next: () => fail('should have failed with the network error'),
+      next: () => failTest(),
       error: (error: HttpErrorResponse) => {
         expect(error.error).toBe(mockError);
       },
@@ -187,14 +187,13 @@ describe('RecipeService', () => {
     // Check that getRandomRecipe returns an error if the request failed
     const testUrl = Constants.recipesPath;
     const testFilter: RecipeFilter = {};
-    const mockError = new ProgressEvent('error');
 
     httpClient
       .get<Recipe[]>(testUrl, {
         params: recipeFilterParams(testFilter),
       })
       .subscribe({
-        next: () => fail('should have failed with the network error'),
+        next: () => failTest(),
         error: (error: HttpErrorResponse) => {
           expect(error.error).toBe(mockError);
         },
@@ -240,10 +239,9 @@ describe('RecipeService', () => {
       view: true,
       isFavorite: true,
     };
-    const mockError = new ProgressEvent('error');
 
     httpClient.patch<Token>(testUrl, recipeUpdate).subscribe({
-      next: () => fail('should have failed with the network error'),
+      next: () => failTest(),
       error: (error: HttpErrorResponse) => {
         expect(error.error).toBe(mockError);
       },

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -12,7 +12,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { environment } from 'src/environments/environment';
 import { mockRecipe, mockRecipes } from '../models/recipe.mock';
-import Recipe, { RecipeWithTimestamp } from '../models/recipe.model';
+import Recipe, { RecentRecipe } from '../models/recipe.model';
 import { RecipeService } from './recipe.service';
 import Constants from '../constants/constants';
 import RecipeFilter from '../models/recipe-filter.model';
@@ -24,10 +24,11 @@ describe('RecipeService', () => {
   let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
 
-  const mockRecipesWithTimestamp: RecipeWithTimestamp[] = mockRecipes.map(
+  const mockRecipesWithTimestamp: RecentRecipe[] = mockRecipes.map(
     (recipe, index) => ({
       ...recipe,
       timestamp: index,
+      isFavorite: false,
     })
   );
 

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -85,15 +85,17 @@ export class RecipeService {
       return this.getMockToken();
     }
 
-    return this.http.patch<Token>(
-      `${environment.serverBaseUrl}${Constants.recipesPath}/${id}`,
-      fields,
-      {
-        headers: {
-          ...(token !== undefined && this.authHeader(token)),
-        },
-      }
-    );
+    return this.http
+      .patch<Token>(
+        `${environment.serverBaseUrl}${Constants.recipesPath}/${id}`,
+        fields,
+        {
+          headers: {
+            ...(token !== undefined && this.authHeader(token)),
+          },
+        }
+      )
+      .pipe(catchError(this.handleError.bind(this)));
   }
 
   // Load a sample recipe to avoid hitting the API while testing the UI

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -147,7 +147,7 @@ export class RecipeService {
     // dexie's Observable type isn't the same as rxjs's Observable type
     return liveQuery(() =>
       recentRecipesDB.recipes
-        .orderBy(Constants.recentRecipesDB.indexes.timestamp)
+        .orderBy(Constants.recentRecipesDB.config.at(-1)!.indexes.timestamp)
         .reverse()
         .toArray()
     );
@@ -170,7 +170,7 @@ export class RecipeService {
 
         if (recipeCount >= Constants.recentRecipesDB.max) {
           const oldestRecipe = await recentRecipesDB.recipes
-            .orderBy(Constants.recentRecipesDB.indexes.timestamp)
+            .orderBy(Constants.recentRecipesDB.config.at(-1)!.indexes.timestamp)
             .first();
           await recentRecipesDB.recipes.delete(oldestRecipe!.id);
         }
@@ -178,6 +178,7 @@ export class RecipeService {
         await recentRecipesDB.recipes.add({
           ...recipe,
           timestamp: Date.now(),
+          isFavorite: false,
         });
       }
     );

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -3,9 +3,9 @@ import { Injectable, inject } from '@angular/core';
 import { liveQuery } from 'dexie';
 import { BehaviorSubject, catchError, Observable, throwError } from 'rxjs';
 
-import Recipe from '../models/recipe.model';
+import Recipe, { RecipeUpdate, Token } from '../models/recipe.model';
 import { environment } from 'src/environments/environment';
-import { mockRecipe, mockRecipes } from '../models/recipe.mock';
+import { mockRecipe, mockRecipes, mockToken } from '../models/recipe.mock';
 import RecipeError from '../models/recipe-error.model';
 import Constants from '../constants/constants';
 import RecipeFilter from '../models/recipe-filter.model';
@@ -17,6 +17,7 @@ import recentRecipesDB from '../helpers/recent-recipes-db';
 })
 export class RecipeService {
   private http = inject(HttpClient);
+  private readonly isMocking = !environment.production && environment.mock;
 
   // Store the recipe object in the service so other components can reference it and observe changes
   private recipe = new BehaviorSubject<Recipe | null>(null);
@@ -38,7 +39,7 @@ export class RecipeService {
 
   // API methods
   getRecipesWithFilter(filter: RecipeFilter): Observable<Recipe[]> {
-    if (!environment.production && environment.mock) {
+    if (this.isMocking) {
       return this.getMockRecipes();
     }
 
@@ -51,7 +52,7 @@ export class RecipeService {
 
   getRandomRecipe(): Observable<Recipe> {
     // Mock the network calls for easier debugging & no quotas
-    if (!environment.production && environment.mock) {
+    if (this.isMocking) {
       return this.getMockRecipe();
     }
 
@@ -66,13 +67,33 @@ export class RecipeService {
   }
 
   getRecipeById(id: string): Observable<Recipe> {
-    if (!environment.production && environment.mock) {
+    if (this.isMocking) {
       return this.getMockRecipe();
     }
 
     return this.http
       .get<Recipe>(`${environment.serverBaseUrl}${Constants.recipesPath}/${id}`)
       .pipe(catchError(this.handleError.bind(this)));
+  }
+
+  updateRecipe(
+    id: number,
+    fields: RecipeUpdate,
+    token?: string
+  ): Observable<Token> {
+    if (this.isMocking) {
+      return this.getMockToken();
+    }
+
+    return this.http.patch<Token>(
+      `${environment.serverBaseUrl}${Constants.recipesPath}/${id}`,
+      fields,
+      {
+        headers: {
+          ...(token !== undefined && this.authHeader(token)),
+        },
+      }
+    );
   }
 
   // Load a sample recipe to avoid hitting the API while testing the UI
@@ -101,6 +122,23 @@ export class RecipeService {
             subscriber.error(Error('A mock error occurred.'));
           } else {
             subscriber.next(mockRecipes);
+          }
+
+          subscriber.complete();
+        },
+        this.mockLoading ? 10_000 : 0
+      );
+    });
+  }
+
+  getMockToken(): Observable<Token> {
+    return new Observable((subscriber) => {
+      setTimeout(
+        () => {
+          if (this.mockError) {
+            subscriber.error(Error('A mock error occurred.'));
+          } else {
+            subscriber.next(mockToken);
           }
 
           subscriber.complete();
@@ -139,6 +177,12 @@ export class RecipeService {
     }
 
     return Object.prototype.hasOwnProperty.call(error, 'error');
+  }
+
+  private authHeader(token: string) {
+    return {
+      Authorization: `Bearer ${token}`,
+    };
   }
 
   // IndexedDB methods

--- a/src/app/services/terms.service.spec.ts
+++ b/src/app/services/terms.service.spec.ts
@@ -27,6 +27,8 @@ describe('TermsService', () => {
 
   const testUrl = Constants.termsPath;
   const localStorageProto = Object.getPrototypeOf(localStorage);
+  const mockError = new ProgressEvent('error');
+  const failTest = () => fail('should have failed with the network error');
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -68,10 +70,8 @@ describe('TermsService', () => {
 
   it('should return an error if the terms API fails', () => {
     // Check that getTerms returns an error if the request failed
-    const mockError = new ProgressEvent('error');
-
     httpClient.get<Term[]>(testUrl).subscribe({
-      next: () => fail('should have failed with the network error'),
+      next: () => failTest(),
       error: (error: HttpErrorResponse) => {
         expect(error.error).toBe(mockError);
       },

--- a/src/app/services/terms.service.ts
+++ b/src/app/services/terms.service.ts
@@ -13,11 +13,11 @@ import TermStore from '../models/term-store.model';
 })
 export class TermsService {
   private http = inject(HttpClient);
-
+  private readonly isMocking = !environment.production && environment.mock;
 
   // API methods
   getTerms(): Observable<Term[]> {
-    if (!environment.production && environment.mock) {
+    if (this.isMocking) {
       return this.getMockTerms();
     }
 


### PR DESCRIPTION
_The (partial) web implementation of #312_

Finally, we're updating the web app! First things first, I added all the models and APIs to handle authentication. I also went ahead and created a new profile component, but hid it in prod since, unlike mobile, all web changes are deployed instantly.

I also updated the recent recipe schema and adjusted the Dexie config to support multiple versions of a table (with a clear distinction between a DB and a table).

The service tests saw a major overhaul since I learned how to incorporate promises with observables. I believe what I was doing previously was creating an API call on-the-fly and asserting that the API matches how I set it up a few lines above. These tests now explicitly call the service method to await an actual response. We can still mock the response to our liking, but the API logic now goes through the service itself. The assertions now check how the service was implemented, rather than how the test was set up. Plus, I can add additional assertions, such as checking the header and body. Besides that, I made some other changes to reduce the amount of repetitive code for maintainability.

If there's nothing else I'm forgetting, the next step will be to start looking into how to handle authentication and login forms in Angular.