### PR TITLE
Profile Pt 3: Token Auth

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -43,7 +43,7 @@ export const profileRoutes: Record<string, Route> = {
     title: 'Verify Email',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.VerifyEmailComponent),
-    canActivate: [devGuard],
+    canActivate: [devGuard, authGuard],
   },
   updateEmail: {
     path: 'profile/update-email',

--- a/src/app/components/glossary/glossary.component.ts
+++ b/src/app/components/glossary/glossary.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, OnInit, inject } from '@angular/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatListModule } from '@angular/material/list';

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
@@ -19,8 +18,8 @@ import { RecipeCardComponent } from '../recipe-card/recipe-card.component';
     MatButtonModule,
     MatDividerModule,
     MatProgressSpinnerModule,
-    RecipeCardComponent
-],
+    RecipeCardComponent,
+  ],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss',
 })

--- a/src/app/components/navbar/navbar.component.spec.ts
+++ b/src/app/components/navbar/navbar.component.spec.ts
@@ -3,7 +3,6 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 
 import { NavbarComponent } from './navbar.component';
-import { routes } from 'src/app/app-routing.module';
 
 describe('NavbarComponent', () => {
   let navbarComponent: NavbarComponent;
@@ -32,8 +31,9 @@ describe('NavbarComponent', () => {
     const menuIcon = rootElement.querySelector<HTMLButtonElement>('.menu-icon');
     expect(menuIcon).toBeNull();
     expect(rootElement.textContent).toContain('EZ Recipes');
-    expect(rootElement.textContent).toContain(routes.search.title);
-    expect(rootElement.textContent).toContain(routes.glossary.title);
+    for (const route of navbarComponent.navItems) {
+      expect(rootElement.textContent).toContain(route.title);
+    }
 
     // The favorite and share buttons should be hidden by default on the home page
     const favoriteIcon =
@@ -54,9 +54,9 @@ describe('NavbarComponent', () => {
     const menuIcon = rootElement.querySelector<HTMLButtonElement>('.menu-icon');
     expect(menuIcon).not.toBeNull();
     expect(rootElement.textContent).toContain('EZ Recipes');
-    expect(rootElement.textContent).toContain(routes.home.title);
-    expect(rootElement.textContent).toContain(routes.search.title);
-    expect(rootElement.textContent).toContain(routes.glossary.title);
+    for (const route of navbarComponent.navItems) {
+      expect(rootElement.textContent).toContain(route.title);
+    }
 
     // The favorite and share buttons should be hidden by default on the home page
     const favoriteIcon =

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,5 +1,4 @@
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-
 import { Component, OnDestroy, OnInit, Type, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -23,8 +22,8 @@ import { environment } from 'src/environments/environment';
     MatListModule,
     MatSidenavModule,
     MatToolbarModule,
-    RouterModule
-],
+    RouterModule,
+  ],
   templateUrl: './navbar.component.html',
   styleUrl: './navbar.component.scss',
 })

--- a/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
@@ -5,11 +5,11 @@ import {
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
 import { ChefService } from 'src/app/services/chef.service';
 import { ChefUpdateType } from 'src/app/models/profile.model';
-import { of } from 'rxjs';
 import { mockChefEmailResponse } from 'src/app/models/profile.mock';
 
 describe('ForgotPasswordComponent', () => {

--- a/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
@@ -9,8 +9,9 @@ import { RouterModule } from '@angular/router';
 import { ForgotPasswordComponent } from './forgot-password.component';
 
 describe('ForgotPasswordComponent', () => {
-  let component: ForgotPasswordComponent;
+  let forgotPasswordComponent: ForgotPasswordComponent;
   let fixture: ComponentFixture<ForgotPasswordComponent>;
+  let rootElement: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -22,11 +23,12 @@ describe('ForgotPasswordComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(ForgotPasswordComponent);
-    component = fixture.componentInstance;
+    forgotPasswordComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(forgotPasswordComponent).toBeTruthy();
   });
 });

--- a/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
@@ -7,18 +7,29 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
+import { ChefService } from 'src/app/services/chef.service';
+import { ChefUpdateType } from 'src/app/models/profile.model';
+import { of } from 'rxjs';
+import { mockChefEmailResponse } from 'src/app/models/profile.mock';
 
 describe('ForgotPasswordComponent', () => {
   let forgotPasswordComponent: ForgotPasswordComponent;
   let fixture: ComponentFixture<ForgotPasswordComponent>;
   let rootElement: HTMLElement;
+  let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
+    mockChefService = jasmine.createSpyObj('ChefService', ['updateChef']);
+
     await TestBed.configureTestingModule({
       imports: [ForgotPasswordComponent, RouterModule.forRoot([])],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        {
+          provide: ChefService,
+          useValue: mockChefService,
+        },
       ],
     }).compileComponents();
 
@@ -28,7 +39,74 @@ describe('ForgotPasswordComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should ask for an email initially', () => {
     expect(forgotPasswordComponent).toBeTruthy();
+    expect(rootElement.textContent).toContain('No problem!');
+
+    const emailField = rootElement.querySelector<HTMLInputElement>('input');
+    expect(emailField).toBeTruthy();
+    expect(emailField?.type).toBe('email');
+    expect(emailField?.inputMode).toBe('email');
+    expect(emailField?.autocapitalize).toBe('none');
+    expect(emailField?.autocomplete).toBe('off');
+    expect(emailField?.spellcheck).toBeFalse();
+
+    const submitButton = rootElement.querySelector('button');
+    expect(submitButton).toBeTruthy();
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should show that an email was sent', () => {
+    forgotPasswordComponent.emailSent.set(true);
+    fixture.detectChanges();
+
+    expect(rootElement.textContent).toContain('We sent an email to');
+  });
+
+  it("should show an error if the email isn't provided", () => {
+    const form = forgotPasswordComponent.formGroup;
+    form.controls.email.setValue(null);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.email.hasError(forgotPasswordComponent.formErrors.required)
+    );
+    const submitButton = rootElement.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it("should show an error if the email isn't valid", () => {
+    const form = forgotPasswordComponent.formGroup;
+    form.controls.email.setValue('not an email');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.email.hasError(
+        forgotPasswordComponent.formErrors.emailInvalid
+      )
+    );
+    const submitButton = rootElement.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should enable the submit button if all fields are valid', () => {
+    const form = forgotPasswordComponent.formGroup;
+    const mockEmail = 'test@example.com';
+    form.controls.email.setValue(mockEmail);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeTrue();
+    const submitButton = rootElement.querySelector('button');
+    expect(submitButton?.disabled).toBeFalse();
+
+    mockChefService.updateChef.and.returnValue(of(mockChefEmailResponse));
+    submitButton?.click();
+    expect(mockChefService.updateChef).toHaveBeenCalledWith({
+      type: ChefUpdateType.Password,
+      email: mockEmail,
+    });
+    expect(forgotPasswordComponent.emailSent()).toBeTrue();
   });
 });

--- a/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/components/profile/forgot-password/forgot-password.component.spec.ts
@@ -71,7 +71,7 @@ describe('ForgotPasswordComponent', () => {
     expect(form.valid).toBeFalse();
     expect(
       form.controls.email.hasError(forgotPasswordComponent.formErrors.required)
-    );
+    ).toBeTrue();
     const submitButton = rootElement.querySelector('button');
     expect(submitButton?.disabled).toBeTrue();
   });
@@ -86,7 +86,7 @@ describe('ForgotPasswordComponent', () => {
       form.controls.email.hasError(
         forgotPasswordComponent.formErrors.emailInvalid
       )
-    );
+    ).toBeTrue();
     const submitButton = rootElement.querySelector('button');
     expect(submitButton?.disabled).toBeTrue();
   });

--- a/src/app/components/profile/forgot-password/forgot-password.component.ts
+++ b/src/app/components/profile/forgot-password/forgot-password.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, inject, OnDestroy, signal } from '@angular/core';
 import {
   ReactiveFormsModule,
@@ -28,8 +27,8 @@ import { ChefService } from 'src/app/services/chef.service';
     MatInputModule,
     MatProgressSpinnerModule,
     ReactiveFormsModule,
-    RouterModule
-],
+    RouterModule,
+  ],
   templateUrl: './forgot-password.component.html',
   styleUrl: './forgot-password.component.scss',
 })

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -9,8 +9,9 @@ import { RouterModule } from '@angular/router';
 import { LoginComponent } from './login.component';
 
 describe('LoginComponent', () => {
-  let component: LoginComponent;
+  let loginComponent: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
+  let rootElement: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -22,11 +23,12 @@ describe('LoginComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginComponent);
-    component = fixture.componentInstance;
+    loginComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(loginComponent).toBeTruthy();
   });
 });

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -4,24 +4,43 @@ import {
 } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { of } from 'rxjs';
 
 import { LoginComponent } from './login.component';
+import { ChefService } from 'src/app/services/chef.service';
+import {
+  mockChefEmailResponse,
+  mockLoginResponse,
+} from 'src/app/models/profile.mock';
+import { profileRoutes } from 'src/app/app-routing.module';
 
 describe('LoginComponent', () => {
   let loginComponent: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
   let rootElement: HTMLElement;
+  let router: Router;
+  let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
+    mockChefService = jasmine.createSpyObj('ChefService', [
+      'login',
+      'verifyEmail',
+    ]);
+
     await TestBed.configureTestingModule({
       imports: [LoginComponent, RouterModule.forRoot([])],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        {
+          provide: ChefService,
+          useValue: mockChefService,
+        },
       ],
     }).compileComponents();
 
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(LoginComponent);
     loginComponent = fixture.componentInstance;
     rootElement = fixture.nativeElement;
@@ -35,5 +54,73 @@ describe('LoginComponent', () => {
     expect(rootElement.textContent).toContain('Username');
     expect(rootElement.textContent).toContain('Password');
     expect(rootElement.textContent).toContain('Forgot Password?');
+
+    const loginFields = rootElement.querySelector('.login-fields');
+    const [usernameField, passwordField] = Array.from(
+      loginFields?.querySelectorAll<HTMLInputElement>('input') ?? []
+    );
+    expect(usernameField.type).toBe('email');
+    expect(usernameField.inputMode).toBe('email');
+    expect(usernameField.autocapitalize).toBe('none');
+    expect(usernameField.autocomplete).toBe('off');
+    expect(usernameField.spellcheck).toBeFalse();
+
+    expect(passwordField.type).toBe('password');
+    expect(passwordField.autocapitalize).toBe('none');
+    expect(passwordField.autocomplete).toBe('off');
+    expect(passwordField.spellcheck).toBeFalse();
+
+    loginComponent.showPassword.set(true);
+    fixture.detectChanges();
+    expect(passwordField.type).toBe('text');
+    loginComponent.showPassword.set(false);
+    fixture.detectChanges();
+    expect(passwordField.type).toBe('password');
+  });
+
+  it("should show an error if the username or password isn't provided", () => {
+    const form = loginComponent.formGroup;
+    form.controls.username.setValue(null);
+    form.controls.password.setValue(null);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(form.controls.username.hasError('required')).toBeTrue();
+    expect(form.controls.password.hasError('required')).toBeTrue();
+
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should enable the submit button if all fields are valid', () => {
+    const form = loginComponent.formGroup;
+    const mockEmail = 'test@example.com';
+    const mockPassword = 'password123';
+    form.controls.username.setValue(mockEmail);
+    form.controls.password.setValue(mockPassword);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeFalse();
+
+    mockChefService.login.and.returnValue(of(mockLoginResponse(false)));
+    mockChefService.verifyEmail.and.returnValue(of(mockChefEmailResponse));
+    const navigateSpy = spyOn(router, 'navigate');
+    submitButton?.click();
+    fixture.detectChanges();
+
+    expect(mockChefService.login).toHaveBeenCalledWith({
+      email: mockEmail,
+      password: mockPassword,
+    });
+    expect(mockChefService.verifyEmail).toHaveBeenCalledWith(
+      mockLoginResponse(false).token
+    );
+    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path]);
   });
 });

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -11,6 +11,7 @@ import { LoginComponent } from './login.component';
 describe('LoginComponent', () => {
   let loginComponent: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let rootElement: HTMLElement;
 
   beforeEach(async () => {

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -11,7 +11,6 @@ import { LoginComponent } from './login.component';
 describe('LoginComponent', () => {
   let loginComponent: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let rootElement: HTMLElement;
 
   beforeEach(async () => {
@@ -31,5 +30,10 @@ describe('LoginComponent', () => {
 
   it('should create', () => {
     expect(loginComponent).toBeTruthy();
+    expect(rootElement.textContent).toContain('Login');
+    expect(rootElement.textContent).toContain('Sign Up');
+    expect(rootElement.textContent).toContain('Username');
+    expect(rootElement.textContent).toContain('Password');
+    expect(rootElement.textContent).toContain('Forgot Password?');
   });
 });

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -16,7 +16,7 @@ import { Subscription } from 'rxjs';
 
 import { ChefService } from 'src/app/services/chef.service';
 import { LoginCredentials } from 'src/app/models/profile.model';
-import { profileRoutes } from 'src/app/app-routing.module';
+import { profileRoutes, routes } from 'src/app/app-routing.module';
 import Constants from 'src/app/constants/constants';
 
 @Component({
@@ -103,7 +103,7 @@ export class LoginComponent implements OnDestroy {
             if (redirectUrl !== null) {
               this.router.navigateByUrl(redirectUrl);
             } else {
-              this.router.navigate([profileRoutes.profile.path]);
+              this.router.navigate([routes.profile.path]);
             }
           }
         },

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -77,26 +77,16 @@ export class LoginComponent implements OnDestroy {
     this.chefServiceSubscription = this.chefService
       .login(loginCredentials)
       .subscribe({
-        next: ({ uid, token, emailVerified }) => {
+        next: ({ token, emailVerified }) => {
           this.isLoading.set(false);
           localStorage.setItem(Constants.LocalStorage.token, token);
 
           // Check if the user signed up, but didn't verify their email yet
           if (!emailVerified) {
             // Don't update the chef's verified status until they click the redirect link
-            this.chefService.verifyEmail(token);
+            this.chefService.verifyEmail(token).subscribe();
             this.router.navigate([profileRoutes.verifyEmail.path]);
           } else {
-            // Fetch the rest of the chef's profile
-            this.chefService.getChef(token).subscribe({
-              next: (chef) => {
-                console.log('Chef profile:', chef);
-              },
-              error: (error) => {
-                console.error('Error fetching chef:', error);
-              },
-            });
-
             // If a redirect URL is present in the query params, navigate to it
             // Otherwise, navigate to the profile page
             const redirectUrl = this.route.snapshot.queryParamMap.get('next');

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, inject, OnDestroy, signal } from '@angular/core';
 import {
   FormControl,
@@ -12,12 +11,13 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { ChefService } from 'src/app/services/chef.service';
 import { LoginCredentials } from 'src/app/models/profile.model';
 import { profileRoutes } from 'src/app/app-routing.module';
+import Constants from 'src/app/constants/constants';
 
 @Component({
   selector: 'app-login',
@@ -28,14 +28,16 @@ import { profileRoutes } from 'src/app/app-routing.module';
     MatInputModule,
     MatProgressSpinnerModule,
     ReactiveFormsModule,
-    RouterModule
-],
+    RouterModule,
+  ],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })
 export class LoginComponent implements OnDestroy {
   private chefService = inject(ChefService);
   private snackBar = inject(MatSnackBar);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
   profileRoutes = profileRoutes;
 
   private chefServiceSubscription?: Subscription;
@@ -75,9 +77,35 @@ export class LoginComponent implements OnDestroy {
     this.chefServiceSubscription = this.chefService
       .login(loginCredentials)
       .subscribe({
-        next: (loginResponse) => {
+        next: ({ uid, token, emailVerified }) => {
           this.isLoading.set(false);
-          console.log('Login successful', loginResponse);
+          localStorage.setItem(Constants.LocalStorage.token, token);
+
+          // Check if the user signed up, but didn't verify their email yet
+          if (!emailVerified) {
+            // Don't update the chef's verified status until they click the redirect link
+            this.chefService.verifyEmail(token);
+            this.router.navigate([profileRoutes.verifyEmail.path]);
+          } else {
+            // Fetch the rest of the chef's profile
+            this.chefService.getChef(token).subscribe({
+              next: (chef) => {
+                console.log('Chef profile:', chef);
+              },
+              error: (error) => {
+                console.error('Error fetching chef:', error);
+              },
+            });
+
+            // If a redirect URL is present in the query params, navigate to it
+            // Otherwise, navigate to the profile page
+            const redirectUrl = this.route.snapshot.queryParamMap.get('next');
+            if (redirectUrl !== null) {
+              this.router.navigateByUrl(redirectUrl);
+            } else {
+              this.router.navigate([profileRoutes.profile.path]);
+            }
+          }
         },
         error: (error) => {
           this.isLoading.set(false);

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -1,42 +1,31 @@
-<!-- Temp buttons to control the auth state -->
-<mat-radio-group (change)="authState = $event.value">
-  <mat-radio-button [value]="AuthState.Unauthenticated">
-    Unauthenticated
-  </mat-radio-button>
-  <mat-radio-button [value]="AuthState.Authenticated">
-    Authenticated
-  </mat-radio-button>
-  <mat-radio-button [value]="AuthState.Loading">Loading</mat-radio-button>
-</mat-radio-group>
-
 <div class="profile-container">
-  @if (authState === AuthState.Authenticated) {
-  <h1>Chef {{ chef.email }}</h1>
+  @if (authState() === AuthState.Authenticated && chef() !== undefined) {
+  <h1>Chef {{ chef()?.email }}</h1>
   <span class="profile-stats">
-    <span [ngPlural]="totalRecipesFavorited">
+    <span [ngPlural]="totalRecipesFavorited()">
       <ng-template ngPluralCase="1">
-        {{ totalRecipesFavorited }} favorite
+        {{ totalRecipesFavorited() }} favorite
       </ng-template>
       <ng-template ngPluralCase="other">
-        {{ totalRecipesFavorited }} favorites
+        {{ totalRecipesFavorited() }} favorites
       </ng-template>
     </span>
     <mat-divider [vertical]="true" />
-    <span [ngPlural]="totalRecipesViewed">
+    <span [ngPlural]="totalRecipesViewed()">
       <ng-template ngPluralCase="1">
-        {{ totalRecipesViewed }} recipe viewed
+        {{ totalRecipesViewed() }} recipe viewed
       </ng-template>
       <ng-template ngPluralCase="other">
-        {{ totalRecipesViewed }} recipes viewed
+        {{ totalRecipesViewed() }} recipes viewed
       </ng-template>
     </span>
     <mat-divider [vertical]="true" />
-    <span [ngPlural]="totalRecipesRated">
+    <span [ngPlural]="totalRecipesRated()">
       <ng-template ngPluralCase="1">
-        {{ totalRecipesRated }} rating</ng-template
+        {{ totalRecipesRated() }} rating</ng-template
       >
       <ng-template ngPluralCase="other">
-        {{ totalRecipesRated }} ratings
+        {{ totalRecipesRated() }} ratings
       </ng-template>
     </span>
   </span>
@@ -52,7 +41,7 @@
       Delete Account
     </button>
   </div>
-  } @else if (authState === AuthState.Unauthenticated) {
+  } @else if (authState() === AuthState.Unauthenticated) {
   <h2 class="profile-unauth-header">
     Signing up for an account is free and gives you great perks, including:
   </h2>

--- a/src/app/components/profile/profile.component.spec.ts
+++ b/src/app/components/profile/profile.component.spec.ts
@@ -1,16 +1,29 @@
+import { Location } from '@angular/common';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import {
+  provideRouter,
+  Router,
+  RouterLink,
+  RouterModule,
+} from '@angular/router';
 
 import { ProfileComponent } from './profile.component';
+import { AuthState } from 'src/app/models/profile.model';
+import { profileRoutes, routes } from 'src/app/app-routing.module';
+import { mockChef } from 'src/app/models/profile.mock';
 
 describe('ProfileComponent', () => {
-  let component: ProfileComponent;
+  let profileComponent: ProfileComponent;
   let fixture: ComponentFixture<ProfileComponent>;
+  let rootElement: HTMLElement;
+  let router: Router;
+  let location: Location;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -18,15 +31,89 @@ describe('ProfileComponent', () => {
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        provideRouter(Object.values(routes)),
       ],
     }).compileComponents();
 
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(null);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => {});
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
+
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
     fixture = TestBed.createComponent(ProfileComponent);
-    component = fixture.componentInstance;
+    profileComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
+    router.initialNavigation();
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(profileComponent).toBeTruthy();
+  });
+
+  it('should show a loading message when the auth state is loading', () => {
+    profileComponent.authState.set(AuthState.Loading);
+    fixture.detectChanges();
+
+    expect(rootElement.textContent).toContain('Getting your profile ready… 🧑‍🍳');
+  });
+
+  it("should show the login button if the user isn't authenticated", async () => {
+    expect(profileComponent.authState()).toBe(AuthState.Unauthenticated);
+
+    expect(rootElement.textContent).toContain(
+      'Signing up for an account is free'
+    );
+    const loginButton = fixture.debugElement.query(By.directive(RouterLink));
+    loginButton.nativeElement.click();
+    await fixture.whenStable(); // wait for routing to finish
+    expect(location.path()).toBe(`/${profileRoutes.login.path}`);
+  });
+
+  it('should show the profile page if the user is authenticated', async () => {
+    profileComponent.authState.set(AuthState.Authenticated);
+    profileComponent.chef.set(mockChef);
+    fixture.detectChanges();
+
+    const profileStats = rootElement.querySelector('.profile-stats');
+    expect(profileStats?.textContent).toContain(
+      `${profileComponent.totalRecipesFavorited()} favorite`
+    );
+    expect(profileStats?.textContent).toContain(
+      `${profileComponent.totalRecipesViewed()} recipes viewed`
+    );
+    expect(profileStats?.textContent).toContain(
+      `${profileComponent.totalRecipesRated()} ratings`
+    );
+
+    const profileActions = rootElement.querySelector('.profile-actions');
+    const [
+      logoutButton,
+      changeEmailButton,
+      changePasswordButton,
+      deleteAccountButton,
+    ] = Array.from(profileActions?.querySelectorAll('button') ?? []);
+    expect(logoutButton).toBeTruthy();
+    expect(changeEmailButton).toBeTruthy();
+    expect(changePasswordButton).toBeTruthy();
+    expect(deleteAccountButton).toBeTruthy();
+
+    const navigateSpy = spyOn(router, 'navigate');
+    changeEmailButton.click();
+    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.updateEmail.path]);
+    changePasswordButton.click();
+    expect(navigateSpy).toHaveBeenCalledWith([
+      profileRoutes.updatePassword.path,
+    ]);
+    deleteAccountButton.click();
+    expect(navigateSpy).toHaveBeenCalledWith([
+      profileRoutes.deleteAccount.path,
+    ]);
+
+    logoutButton.click();
+    fixture.detectChanges();
+    expect(profileComponent.authState()).toBe(AuthState.Unauthenticated);
   });
 });

--- a/src/app/components/profile/profile.component.spec.ts
+++ b/src/app/components/profile/profile.component.spec.ts
@@ -1,3 +1,8 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProfileComponent } from './profile.component';
@@ -8,9 +13,12 @@ describe('ProfileComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProfileComponent]
-    })
-    .compileComponents();
+      imports: [ProfileComponent],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ProfileComponent);
     component = fixture.componentInstance;

--- a/src/app/components/profile/profile.component.spec.ts
+++ b/src/app/components/profile/profile.component.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
 
 import { ProfileComponent } from './profile.component';
 
@@ -13,7 +14,7 @@ describe('ProfileComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProfileComponent],
+      imports: [ProfileComponent, RouterModule.forRoot([])],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -1,14 +1,15 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
-import { Router, RouterModule } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 import { mockChef } from 'src/app/models/profile.mock';
-import { AuthState } from 'src/app/models/profile.model';
+import { AuthState, ProfileAction } from 'src/app/models/profile.model';
 import { profileRoutes, routes } from 'src/app/app-routing.module';
 import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
@@ -27,9 +28,11 @@ import { ChefService } from 'src/app/services/chef.service';
   templateUrl: './profile.component.html',
   styleUrl: './profile.component.scss',
 })
-export class ProfileComponent {
+export class ProfileComponent implements OnInit {
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
   private chefService = inject(ChefService);
+  private snackBar = inject(MatSnackBar);
 
   AuthState = AuthState;
   authState = AuthState.Loading;
@@ -39,6 +42,27 @@ export class ProfileComponent {
   readonly totalRecipesFavorited = this.chef.favoriteRecipes.length;
   readonly totalRecipesViewed = Object.keys(this.chef.recentRecipes).length;
   readonly totalRecipesRated = Object.keys(this.chef.ratings).length;
+
+  ngOnInit(): void {
+    const action = this.route.snapshot.queryParamMap.get('action');
+
+    switch (action) {
+      case ProfileAction.VerifyEmail:
+        this.snackBar.open('Email verified successfully!', 'Dismiss');
+        break;
+      case ProfileAction.ChangeEmail:
+        this.snackBar.open(
+          'Email updated successfully! Please sign in again.',
+          'Dismiss'
+        );
+        break;
+      case ProfileAction.ResetPassword:
+        this.snackBar.open(
+          'Password updated successfully! Please sign in again.',
+          'Dismiss'
+        );
+    }
+  }
 
   logout() {
     const token = localStorage.getItem(Constants.LocalStorage.token);

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -9,7 +9,9 @@ import { Router, RouterModule } from '@angular/router';
 
 import { mockChef } from 'src/app/models/profile.mock';
 import { AuthState } from 'src/app/models/profile.model';
-import { profileRoutes } from 'src/app/app-routing.module';
+import { profileRoutes, routes } from 'src/app/app-routing.module';
+import Constants from 'src/app/constants/constants';
+import { ChefService } from 'src/app/services/chef.service';
 
 @Component({
   selector: 'app-profile',
@@ -27,6 +29,7 @@ import { profileRoutes } from 'src/app/app-routing.module';
 })
 export class ProfileComponent {
   private router = inject(Router);
+  private chefService = inject(ChefService);
 
   AuthState = AuthState;
   authState = AuthState.Loading;
@@ -38,7 +41,13 @@ export class ProfileComponent {
   readonly totalRecipesRated = Object.keys(this.chef.ratings).length;
 
   logout() {
-    console.log('Logout');
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token !== null) {
+      this.chefService.logout(token);
+    }
+    // Assume the user should be signed out since there's no auth token
+    localStorage.removeItem(Constants.LocalStorage.token);
+    this.router.navigate([routes.profile.path]);
   }
 
   changeEmail() {

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -1,16 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatRadioModule } from '@angular/material/radio';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
-import { mockChef } from 'src/app/models/profile.mock';
-import { AuthState, ProfileAction } from 'src/app/models/profile.model';
-import { profileRoutes, routes } from 'src/app/app-routing.module';
+import { AuthState, Chef, ProfileAction } from 'src/app/models/profile.model';
+import { profileRoutes } from 'src/app/app-routing.module';
 import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
 
@@ -22,7 +20,6 @@ import { ChefService } from 'src/app/services/chef.service';
     MatDividerModule,
     MatIconModule,
     MatProgressSpinnerModule,
-    MatRadioModule,
     RouterModule,
   ],
   templateUrl: './profile.component.html',
@@ -35,15 +32,48 @@ export class ProfileComponent implements OnInit {
   private snackBar = inject(MatSnackBar);
 
   AuthState = AuthState;
-  authState = AuthState.Loading;
-  chef = mockChef;
+  authState = signal(AuthState.Loading);
+  chef = signal<Chef | undefined>(undefined);
   profileRoutes = profileRoutes;
 
-  readonly totalRecipesFavorited = this.chef.favoriteRecipes.length;
-  readonly totalRecipesViewed = Object.keys(this.chef.recentRecipes).length;
-  readonly totalRecipesRated = Object.keys(this.chef.ratings).length;
+  readonly totalRecipesFavorited = computed(
+    () => this.chef()?.favoriteRecipes.length ?? 0
+  );
+  readonly totalRecipesViewed = computed(
+    () => Object.keys(this.chef()?.recentRecipes ?? {}).length
+  );
+  readonly totalRecipesRated = computed(
+    () => Object.keys(this.chef()?.ratings ?? {}).length
+  );
 
   ngOnInit(): void {
+    // Check if the user is authenticated every time the profile tab is launched
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+
+    if (token === null) {
+      this.authState.set(AuthState.Unauthenticated);
+    } else {
+      this.chefService.getChef(token).subscribe({
+        next: (chefResponse) => {
+          this.chef.set(chefResponse);
+          localStorage.setItem(
+            Constants.LocalStorage.token,
+            chefResponse.token
+          );
+          this.authState.set(
+            chefResponse.emailVerified
+              ? AuthState.Authenticated
+              : AuthState.Unauthenticated
+          );
+        },
+        error: (error) => {
+          localStorage.removeItem(Constants.LocalStorage.token);
+          this.authState.set(AuthState.Unauthenticated);
+          this.snackBar.open(error.message, 'Dismiss');
+        },
+      });
+    }
+
     const action = this.route.snapshot.queryParamMap.get('action');
 
     switch (action) {
@@ -67,11 +97,12 @@ export class ProfileComponent implements OnInit {
   logout() {
     const token = localStorage.getItem(Constants.LocalStorage.token);
     if (token !== null) {
-      this.chefService.logout(token);
+      // subscribe is required to call the API without getting the result
+      this.chefService.logout(token).subscribe();
     }
     // Assume the user should be signed out since there's no auth token
     localStorage.removeItem(Constants.LocalStorage.token);
-    this.router.navigate([routes.profile.path]);
+    this.authState.set(AuthState.Unauthenticated);
   }
 
   changeEmail() {

--- a/src/app/components/profile/sign-up/sign-up.component.spec.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.spec.ts
@@ -9,8 +9,9 @@ import { RouterModule } from '@angular/router';
 import { SignUpComponent } from './sign-up.component';
 
 describe('SignUpComponent', () => {
-  let component: SignUpComponent;
+  let signUpComponent: SignUpComponent;
   let fixture: ComponentFixture<SignUpComponent>;
+  let rootElement: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -22,11 +23,12 @@ describe('SignUpComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(SignUpComponent);
-    component = fixture.componentInstance;
+    signUpComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(signUpComponent).toBeTruthy();
   });
 });

--- a/src/app/components/profile/sign-up/sign-up.component.spec.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.spec.ts
@@ -11,6 +11,7 @@ import { SignUpComponent } from './sign-up.component';
 describe('SignUpComponent', () => {
   let signUpComponent: SignUpComponent;
   let fixture: ComponentFixture<SignUpComponent>;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let rootElement: HTMLElement;
 
   beforeEach(async () => {

--- a/src/app/components/profile/sign-up/sign-up.component.spec.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.spec.ts
@@ -4,24 +4,38 @@ import {
 } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { of } from 'rxjs';
 
 import { SignUpComponent } from './sign-up.component';
+import { ChefService } from 'src/app/services/chef.service';
 
 describe('SignUpComponent', () => {
   let signUpComponent: SignUpComponent;
   let fixture: ComponentFixture<SignUpComponent>;
   let rootElement: HTMLElement;
+  let router: Router;
+  let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
+    mockChefService = jasmine.createSpyObj('ChefService', [
+      'createChef',
+      'verifyEmail',
+    ]);
+
     await TestBed.configureTestingModule({
       imports: [SignUpComponent, RouterModule.forRoot([])],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        {
+          provide: ChefService,
+          useValue: mockChefService,
+        },
       ],
     }).compileComponents();
 
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(SignUpComponent);
     signUpComponent = fixture.componentInstance;
     rootElement = fixture.nativeElement;

--- a/src/app/components/profile/sign-up/sign-up.component.spec.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.spec.ts
@@ -9,6 +9,11 @@ import { of } from 'rxjs';
 
 import { SignUpComponent } from './sign-up.component';
 import { ChefService } from 'src/app/services/chef.service';
+import {
+  mockChefEmailResponse,
+  mockLoginResponse,
+} from 'src/app/models/profile.mock';
+import { profileRoutes } from 'src/app/app-routing.module';
 
 describe('SignUpComponent', () => {
   let signUpComponent: SignUpComponent;
@@ -52,5 +57,144 @@ describe('SignUpComponent', () => {
     expect(rootElement.textContent).toContain(
       'Password must be at least 8 characters long'
     );
+
+    const signUpFields = rootElement.querySelector('.signup-fields');
+    const [emailField, passwordField, confirmPasswordField] = Array.from(
+      signUpFields?.querySelectorAll<HTMLInputElement>('input') ?? []
+    );
+    expect(emailField.type).toBe('email');
+    expect(emailField.inputMode).toBe('email');
+    expect(emailField.autocapitalize).toBe('none');
+    expect(emailField.autocomplete).toBe('off');
+    expect(emailField.spellcheck).toBeFalse();
+
+    expect(passwordField.type).toBe('password');
+    expect(passwordField.autocapitalize).toBe('none');
+    expect(passwordField.autocomplete).toBe('off');
+    expect(passwordField.spellcheck).toBeFalse();
+
+    expect(confirmPasswordField.type).toBe('password');
+    expect(confirmPasswordField.autocapitalize).toBe('none');
+    expect(confirmPasswordField.autocomplete).toBe('off');
+    expect(confirmPasswordField.spellcheck).toBeFalse();
+
+    signUpComponent.showPassword.set(true);
+    fixture.detectChanges();
+    expect(passwordField.type).toBe('text');
+    signUpComponent.showPassword.set(false);
+    fixture.detectChanges();
+    expect(passwordField.type).toBe('password');
+
+    signUpComponent.showPasswordConfirm.set(true);
+    fixture.detectChanges();
+    expect(confirmPasswordField.type).toBe('text');
+    signUpComponent.showPasswordConfirm.set(false);
+    fixture.detectChanges();
+    expect(confirmPasswordField.type).toBe('password');
+  });
+
+  it("should show an error if any field isn't provided", () => {
+    const form = signUpComponent.formGroup;
+    form.controls.email.setValue(null);
+    form.controls.password.setValue(null);
+    form.controls.passwordConfirm.setValue(null);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.email.hasError(signUpComponent.formErrors.required)
+    ).toBeTrue();
+    expect(
+      form.controls.password.hasError(signUpComponent.formErrors.required)
+    ).toBeTrue();
+    expect(
+      form.controls.passwordConfirm.hasError(
+        signUpComponent.formErrors.required
+      )
+    ).toBeFalse();
+
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it("should show an error if the email isn't valid", () => {
+    const form = signUpComponent.formGroup;
+    form.controls.email.setValue('not an email');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.email.hasError(signUpComponent.formErrors.emailInvalid)
+    ).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should show an error if the password is too short', () => {
+    const form = signUpComponent.formGroup;
+    form.controls.password.setValue('123');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.password.hasError(
+        signUpComponent.formErrors.passwordMinLength
+      )
+    ).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it("should show an error if the passwords don't match", () => {
+    const form = signUpComponent.formGroup;
+    form.controls.password.setValue('password1');
+    form.controls.passwordConfirm.setValue('password2');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.hasError(signUpComponent.formErrors.passwordMismatch)
+    ).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should enable the submit button if all fields are valid', () => {
+    const form = signUpComponent.formGroup;
+    const mockEmail = 'test@example.com';
+    const mockPassword = 'password123';
+    form.controls.email.setValue(mockEmail);
+    form.controls.password.setValue(mockPassword);
+    form.controls.passwordConfirm.setValue(mockPassword);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeFalse();
+
+    mockChefService.createChef.and.returnValue(of(mockLoginResponse(false)));
+    mockChefService.verifyEmail.and.returnValue(of(mockChefEmailResponse));
+    const navigateSpy = spyOn(router, 'navigate');
+    submitButton?.click();
+    fixture.detectChanges();
+
+    expect(mockChefService.createChef).toHaveBeenCalledWith({
+      email: mockEmail,
+      password: mockPassword,
+    });
+    expect(mockChefService.verifyEmail).toHaveBeenCalledWith(
+      mockLoginResponse(false).token
+    );
+    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path]);
   });
 });

--- a/src/app/components/profile/sign-up/sign-up.component.spec.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.spec.ts
@@ -11,7 +11,6 @@ import { SignUpComponent } from './sign-up.component';
 describe('SignUpComponent', () => {
   let signUpComponent: SignUpComponent;
   let fixture: ComponentFixture<SignUpComponent>;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let rootElement: HTMLElement;
 
   beforeEach(async () => {
@@ -31,5 +30,13 @@ describe('SignUpComponent', () => {
 
   it('should create', () => {
     expect(signUpComponent).toBeTruthy();
+    expect(rootElement.textContent).toContain('Sign Up');
+    expect(rootElement.textContent).toContain('Sign In');
+    expect(rootElement.textContent).toContain('Email');
+    expect(rootElement.textContent).toContain('Password');
+    expect(rootElement.textContent).toContain('Confirm Password');
+    expect(rootElement.textContent).toContain(
+      'Password must be at least 8 characters long'
+    );
   });
 });

--- a/src/app/components/profile/sign-up/sign-up.component.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.ts
@@ -12,10 +12,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Subscription } from 'rxjs';
 
-import { profileRoutes } from 'src/app/app-routing.module';
+import { profileRoutes, routes } from 'src/app/app-routing.module';
 import Constants from 'src/app/constants/constants';
 import { LoginCredentials } from 'src/app/models/profile.model';
 import { ChefService } from 'src/app/services/chef.service';
@@ -68,6 +68,7 @@ export class SignUpComponent implements OnDestroy {
   private chefService = inject(ChefService);
   private snackBar = inject(MatSnackBar);
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
   profileRoutes = profileRoutes;
 
   private chefServiceSubscription?: Subscription;
@@ -134,6 +135,13 @@ export class SignUpComponent implements OnDestroy {
             // Should always be true
             this.chefService.verifyEmail(token).subscribe();
             this.router.navigate([profileRoutes.verifyEmail.path]);
+          } else {
+            const redirectUrl = this.route.snapshot.queryParamMap.get('next');
+            if (redirectUrl !== null) {
+              this.router.navigateByUrl(redirectUrl);
+            } else {
+              this.router.navigate([routes.profile.path]);
+            }
           }
         },
         error: (error) => {

--- a/src/app/components/profile/sign-up/sign-up.component.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.ts
@@ -126,13 +126,13 @@ export class SignUpComponent implements OnDestroy {
     this.chefServiceSubscription = this.chefService
       .createChef(loginCredentials)
       .subscribe({
-        next: ({ uid, token, emailVerified }) => {
+        next: ({ token, emailVerified }) => {
           this.isLoading.set(false);
           localStorage.setItem(Constants.LocalStorage.token, token);
 
           if (!emailVerified) {
             // Should always be true
-            this.chefService.verifyEmail(token);
+            this.chefService.verifyEmail(token).subscribe();
             this.router.navigate([profileRoutes.verifyEmail.path]);
           }
         },

--- a/src/app/components/profile/sign-up/sign-up.component.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, inject, OnDestroy, signal } from '@angular/core';
 import {
   FormControl,
@@ -60,8 +59,8 @@ const passwordsMatchValidator: ValidatorFn = (control) => {
     MatInputModule,
     MatProgressSpinnerModule,
     ReactiveFormsModule,
-    RouterModule
-],
+    RouterModule,
+  ],
   templateUrl: './sign-up.component.html',
   styleUrl: './sign-up.component.scss',
 })

--- a/src/app/components/profile/verify-email/verify-email.component.html
+++ b/src/app/components/profile/verify-email/verify-email.component.html
@@ -1,1 +1,38 @@
-<p>verify-email works!</p>
+<div class="verify-email-container">
+  <h2>You're Almost There!</h2>
+  <h3>
+    We just need to verify your email before you can put on the chef's hat.<br />
+    Check your email for a magic link sent to <b>{{ email() }}</b
+    ><br /><br />
+
+    ⚠️ We will delete accounts from our system if they're not verified within 1
+    week.
+  </h3>
+
+  <div class="verify-email-retry">
+    <p>Didn't receive an email?</p>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="resendVerificationEmail()"
+      [disabled]="!enableResend()"
+    >
+      Resend
+    </button>
+    <span class="verify-email-clock">
+      <mat-icon fontIcon="schedule" />
+      {{ minutesRemaining() | number : "2.0-0" }}:{{
+        secondsRemaining() % 60 | number : "2.0-0"
+      }}
+    </span>
+  </div>
+
+  <button
+    mat-raised-button
+    color="accent"
+    class="logout-button"
+    (click)="logout()"
+  >
+    Logout
+  </button>
+</div>

--- a/src/app/components/profile/verify-email/verify-email.component.scss
+++ b/src/app/components/profile/verify-email/verify-email.component.scss
@@ -1,0 +1,31 @@
+.verify-email-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin: 16px;
+}
+
+.verify-email-retry {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+
+  > * {
+    margin-bottom: 0;
+  }
+
+  .verify-email-clock {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.logout-button {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/app/components/profile/verify-email/verify-email.component.spec.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.spec.ts
@@ -8,8 +8,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VerifyEmailComponent } from './verify-email.component';
 
 describe('VerifyEmailComponent', () => {
-  let component: VerifyEmailComponent;
+  let verifyEmailComponent: VerifyEmailComponent;
   let fixture: ComponentFixture<VerifyEmailComponent>;
+  let rootElement: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -21,11 +22,12 @@ describe('VerifyEmailComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(VerifyEmailComponent);
-    component = fixture.componentInstance;
+    verifyEmailComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(verifyEmailComponent).toBeTruthy();
   });
 });

--- a/src/app/components/profile/verify-email/verify-email.component.spec.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.spec.ts
@@ -1,3 +1,8 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { VerifyEmailComponent } from './verify-email.component';
@@ -8,9 +13,12 @@ describe('VerifyEmailComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VerifyEmailComponent]
-    })
-    .compileComponents();
+      imports: [VerifyEmailComponent],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(VerifyEmailComponent);
     component = fixture.componentInstance;

--- a/src/app/components/profile/verify-email/verify-email.component.spec.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.spec.ts
@@ -10,6 +10,7 @@ import { VerifyEmailComponent } from './verify-email.component';
 describe('VerifyEmailComponent', () => {
   let verifyEmailComponent: VerifyEmailComponent;
   let fixture: ComponentFixture<VerifyEmailComponent>;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let rootElement: HTMLElement;
 
   beforeEach(async () => {

--- a/src/app/components/profile/verify-email/verify-email.component.spec.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.spec.ts
@@ -4,24 +4,45 @@ import {
 } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { VerifyEmailComponent } from './verify-email.component';
+import { ChefService } from 'src/app/services/chef.service';
+import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
+import { routes } from 'src/app/app-routing.module';
 
 describe('VerifyEmailComponent', () => {
   let verifyEmailComponent: VerifyEmailComponent;
   let fixture: ComponentFixture<VerifyEmailComponent>;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let rootElement: HTMLElement;
+  let router: Router;
+  let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
+    mockChefService = jasmine.createSpyObj('ChefService', [
+      'verifyEmail',
+      'logout',
+    ]);
+
     await TestBed.configureTestingModule({
       imports: [VerifyEmailComponent],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        {
+          provide: ChefService,
+          useValue: mockChefService,
+        },
       ],
     }).compileComponents();
 
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => {});
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
+
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(VerifyEmailComponent);
     verifyEmailComponent = fixture.componentInstance;
     rootElement = fixture.nativeElement;
@@ -30,5 +51,36 @@ describe('VerifyEmailComponent', () => {
 
   it('should create', () => {
     expect(verifyEmailComponent).toBeTruthy();
+    expect(rootElement.textContent).toContain("You're Almost There!");
+    expect(rootElement.textContent).toContain(verifyEmailComponent.email());
+    expect(rootElement.textContent).toContain('⚠️ We will delete accounts');
+    expect(rootElement.textContent).toContain('Resend');
+    expect(rootElement.textContent).toContain('Logout');
+  });
+
+  it('should re-send the verification email', () => {
+    verifyEmailComponent.enableResend.set(true);
+    fixture.detectChanges();
+
+    mockChefService.verifyEmail.and.returnValue(of(mockChefEmailResponse));
+    const resendButton = rootElement
+      .querySelector('.verify-email-retry')
+      ?.querySelector<HTMLButtonElement>('button');
+    resendButton?.click();
+
+    expect(mockChefService.verifyEmail).toHaveBeenCalledWith(mockChef.token);
+    expect(verifyEmailComponent.enableResend()).toBeFalse();
+  });
+
+  it('should logout', () => {
+    mockChefService.logout.and.returnValue(of(null));
+    const navigateSpy = spyOn(router, 'navigate');
+    const logoutButton =
+      rootElement.querySelector<HTMLButtonElement>('.logout-button');
+    logoutButton?.click();
+    fixture.detectChanges();
+
+    expect(mockChefService.logout).toHaveBeenCalledWith(mockChef.token);
+    expect(navigateSpy).toHaveBeenCalledWith([routes.profile.path]);
   });
 });

--- a/src/app/components/profile/verify-email/verify-email.component.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.ts
@@ -47,7 +47,7 @@ export class VerifyEmailComponent {
   resendVerificationEmail() {
     const token = localStorage.getItem(Constants.LocalStorage.token);
     if (token !== null) {
-      this.chefService.verifyEmail(token);
+      this.chefService.verifyEmail(token).subscribe();
     }
     this.enableResend.set(false);
   }
@@ -55,7 +55,7 @@ export class VerifyEmailComponent {
   logout() {
     const token = localStorage.getItem(Constants.LocalStorage.token);
     if (token !== null) {
-      this.chefService.logout(token);
+      this.chefService.logout(token).subscribe();
     }
     // Assume the user should be signed out since there's no auth token
     localStorage.removeItem(Constants.LocalStorage.token);

--- a/src/app/components/profile/verify-email/verify-email.component.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.ts
@@ -1,11 +1,64 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { Router } from '@angular/router';
+
+import Constants from 'src/app/constants/constants';
+import { ChefService } from 'src/app/services/chef.service';
+import { routes } from 'src/app/app-routing.module';
 
 @Component({
   selector: 'app-verify-email',
-  imports: [],
+  imports: [CommonModule, MatButtonModule, MatIconModule],
   templateUrl: './verify-email.component.html',
-  styleUrl: './verify-email.component.scss'
+  styleUrl: './verify-email.component.scss',
 })
 export class VerifyEmailComponent {
+  private chefService = inject(ChefService);
+  private router = inject(Router);
 
+  email = signal('test@example.com');
+  // Throttle the number of times the user can resend the verification email to satisfy API limits
+  enableResend = signal(false);
+  secondsRemaining = signal(Constants.emailCooldownSeconds);
+  minutesRemaining = computed(() => Math.floor(this.secondsRemaining() / 60));
+
+  constructor() {
+    // effect will recompute whenever any signal it references changes,
+    // so we need to use an observable instead
+    toObservable(this.enableResend).subscribe((enableResend) => {
+      if (!enableResend) {
+        this.secondsRemaining.set(Constants.emailCooldownSeconds);
+
+        const emailCooldownTimer = setInterval(() => {
+          this.secondsRemaining.update((secondsRemaing) => secondsRemaing - 1);
+
+          if (this.secondsRemaining() <= 0) {
+            this.enableResend.set(true);
+            clearInterval(emailCooldownTimer);
+          }
+        }, 1000);
+      }
+    });
+  }
+
+  resendVerificationEmail() {
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token !== null) {
+      this.chefService.verifyEmail(token);
+    }
+    this.enableResend.set(false);
+  }
+
+  logout() {
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token !== null) {
+      this.chefService.logout(token);
+    }
+    // Assume the user should be signed out since there's no auth token
+    localStorage.removeItem(Constants.LocalStorage.token);
+    this.router.navigate([routes.profile.path]);
+  }
 }

--- a/src/app/components/profile/verify-email/verify-email.component.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.ts
@@ -19,7 +19,7 @@ export class VerifyEmailComponent {
   private chefService = inject(ChefService);
   private router = inject(Router);
 
-  email = signal('test@example.com');
+  email = signal('test@example.com'); // TODO: replace with actual email
   // Throttle the number of times the user can resend the verification email to satisfy API limits
   enableResend = signal(false);
   secondsRemaining = signal(Constants.emailCooldownSeconds);

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -28,6 +28,7 @@ abstract class Constants {
 
   static LocalStorage = class {
     static readonly terms = 'terms';
+    static readonly token = 'token';
   };
 
   // IndexedDB

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -4,23 +4,25 @@ import { catchError, map, of } from 'rxjs';
 
 import { ChefService } from '../services/chef.service';
 import { profileRoutes } from '../app-routing.module';
+import Constants from '../constants/constants';
 
 // If the user is authenticated, navigate to the route. Otherwise, redirect to the login page.
 export const authGuard: CanActivateFn = (_route, state) => {
   const router = inject(Router);
   const chefService = inject(ChefService);
 
-  return chefService.getChef('').pipe(
-    map(() => {
-      return true;
-    }),
-    catchError(() => {
-      return of(
-        router.createUrlTree([`/${profileRoutes.login.path}`], {
-          // state.url contains the full path, whereas route.url only contains the child path
-          queryParams: { next: state.url },
-        })
-      );
-    })
+  const token = localStorage.getItem(Constants.LocalStorage.token);
+  const loginRedirect = router.createUrlTree([`/${profileRoutes.login.path}`], {
+    // state.url contains the full path, whereas route.url only contains the child path
+    queryParams: { next: state.url },
+  });
+
+  if (token === null) {
+    return loginRedirect;
+  }
+
+  return chefService.getChef(token).pipe(
+    map(() => true),
+    catchError(() => of(loginRedirect))
   );
 };

--- a/src/app/helpers/handleError.ts
+++ b/src/app/helpers/handleError.ts
@@ -1,0 +1,42 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+
+import RecipeError from '../models/recipe-error.model';
+
+// Type guard to check if the server returned a valid error response
+const isRecipeError = (error: unknown): error is RecipeError => {
+  // Assert that error is an object: https://stackoverflow.com/a/8511350
+  if (typeof error !== 'object' || Array.isArray(error) || error === null) {
+    return false;
+  }
+
+  return Object.hasOwn(error, 'error');
+};
+
+/**
+ * Convert an HTTP error response to a user-friendly error message
+ * @param error the error response from an API
+ * @returns an Observable that throws an error with the message
+ */
+const handleError = (error: HttpErrorResponse): Observable<never> => {
+  console.error(error);
+  let errorMessage = '';
+
+  if (error.status === 0) {
+    // An unknown server-side or network issue occurred
+    errorMessage =
+      'An unexpected error occurred. The server may be down or there may be network issues. Please try again later.';
+  } else if (isRecipeError(error.error)) {
+    // Use the error property sent by the server
+    // error.error is the raw HTTP response body
+    errorMessage = error.error.error; // lol
+  } else {
+    // Use the built-in error message for all other kinds of errors
+    errorMessage = error.message;
+  }
+
+  // Return an observable with a user-facing error message.
+  return throwError(() => new Error(errorMessage));
+};
+
+export default handleError;

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -29,8 +29,9 @@ describe('ChefService', () => {
 
   const baseUrl = `${environment.serverBaseUrl}${Constants.chefsPath}`;
   const mockError = new ProgressEvent('error');
-  const mockErrorMessage = (url: string) =>
-    `Http failure response for ${url}: 0 `;
+  const mockErrorMessage =
+    'An unexpected error occurred. The server may be down or there may be network issues. ' +
+    'Please try again later.';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -77,9 +78,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(
-      mockErrorMessage(baseUrl)
-    );
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 
   it('should create a chef', async () => {
@@ -113,9 +112,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(
-      mockErrorMessage(baseUrl)
-    );
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 
   it('should update a chef', async () => {
@@ -172,9 +169,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(
-      mockErrorMessage(baseUrl)
-    );
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 
   it('should delete a chef', async () => {
@@ -201,9 +196,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(
-      mockErrorMessage(baseUrl)
-    );
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 
   it('should verify an email', async () => {
@@ -231,9 +224,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(
-      mockErrorMessage(`${baseUrl}/verify`)
-    );
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 
   it('should login', async () => {
@@ -267,9 +258,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(
-      mockErrorMessage(`${baseUrl}/login`)
-    );
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 
   it('should logout', async () => {
@@ -297,8 +286,6 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expectAsync(chefPromise).toBeRejectedWithError(
-      mockErrorMessage(`${baseUrl}/logout`)
-    );
+    await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
   });
 });

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -1,6 +1,6 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { catchError, Observable, of, throwError } from 'rxjs';
+import { catchError, Observable, of } from 'rxjs';
 
 import {
   Chef,
@@ -16,6 +16,7 @@ import {
   mockChefEmailResponse,
   mockLoginResponse,
 } from '../models/profile.mock';
+import handleError from '../helpers/handleError';
 
 @Injectable({
   providedIn: 'root',
@@ -34,7 +35,7 @@ export class ChefService {
       .get<Chef>(`${environment.serverBaseUrl}${Constants.chefsPath}`, {
         headers: this.authHeader(token),
       })
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   createChef(credentials: LoginCredentials): Observable<LoginResponse> {
@@ -47,7 +48,7 @@ export class ChefService {
         `${environment.serverBaseUrl}${Constants.chefsPath}`,
         credentials
       )
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   updateChef(
@@ -68,7 +69,7 @@ export class ChefService {
           },
         }
       )
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   deleteChef(token: string): Observable<null> {
@@ -80,7 +81,7 @@ export class ChefService {
       .delete<null>(`${environment.serverBaseUrl}${Constants.chefsPath}`, {
         headers: this.authHeader(token),
       })
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   verifyEmail(token: string): Observable<ChefEmailResponse> {
@@ -94,7 +95,7 @@ export class ChefService {
         null, // no body
         { headers: this.authHeader(token) }
       )
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   login(credentials: LoginCredentials): Observable<LoginResponse> {
@@ -107,7 +108,7 @@ export class ChefService {
         `${environment.serverBaseUrl}${Constants.chefsPath}/login`,
         credentials
       )
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   logout(token: string): Observable<null> {
@@ -123,15 +124,10 @@ export class ChefService {
           headers: this.authHeader(token),
         }
       )
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   // Helpers
-  private handleError(error: HttpErrorResponse): Observable<never> {
-    console.error(error);
-    return throwError(() => new Error(error.message));
-  }
-
   private authHeader(token: string) {
     return {
       Authorization: `Bearer ${token}`,

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -28,7 +28,8 @@ describe('RecipeService', () => {
   // at network level. e.g. Connection timeout, DNS error, offline, etc.
   const mockError = new ProgressEvent('error');
   const mockErrorMessage =
-    'An unexpected error occurred. The server may be down or there may be network issues. Please try again later.';
+    'An unexpected error occurred. The server may be down or there may be network issues. ' +
+    'Please try again later.';
   const mockRecipesWithTimestamp: RecentRecipe[] = mockRecipes.map(
     (recipe, index) => ({
       ...recipe,

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -1,16 +1,16 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { liveQuery } from 'dexie';
-import { BehaviorSubject, catchError, Observable, throwError } from 'rxjs';
+import { BehaviorSubject, catchError, Observable } from 'rxjs';
 
 import Recipe, { RecipeUpdate, Token } from '../models/recipe.model';
 import { environment } from 'src/environments/environment';
 import { mockRecipe, mockRecipes, mockToken } from '../models/recipe.mock';
-import RecipeError from '../models/recipe-error.model';
 import Constants from '../constants/constants';
 import RecipeFilter from '../models/recipe-filter.model';
 import recipeFilterParams from './recipe-filter-params';
 import recentRecipesDB from '../helpers/recent-recipes-db';
+import handleError from '../helpers/handleError';
 
 @Injectable({
   providedIn: 'root',
@@ -47,7 +47,7 @@ export class RecipeService {
       .get<Recipe[]>(`${environment.serverBaseUrl}${Constants.recipesPath}`, {
         params: recipeFilterParams(filter),
       })
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   getRandomRecipe(): Observable<Recipe> {
@@ -56,14 +56,11 @@ export class RecipeService {
       return this.getMockRecipe();
     }
 
-    return (
-      this.http
-        .get<Recipe>(
-          `${environment.serverBaseUrl}${Constants.recipesPath}/random`
-        )
-        // Need to bind "this" so "this" in handleError points to RecipeService, instead of undefined
-        .pipe(catchError(this.handleError.bind(this)))
-    );
+    return this.http
+      .get<Recipe>(
+        `${environment.serverBaseUrl}${Constants.recipesPath}/random`
+      )
+      .pipe(catchError(handleError));
   }
 
   getRecipeById(id: string): Observable<Recipe> {
@@ -73,7 +70,7 @@ export class RecipeService {
 
     return this.http
       .get<Recipe>(`${environment.serverBaseUrl}${Constants.recipesPath}/${id}`)
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   updateRecipe(
@@ -95,7 +92,7 @@ export class RecipeService {
           },
         }
       )
-      .pipe(catchError(this.handleError.bind(this)));
+      .pipe(catchError(handleError));
   }
 
   // Load a sample recipe to avoid hitting the API while testing the UI
@@ -148,37 +145,6 @@ export class RecipeService {
         this.mockLoading ? 10_000 : 0
       );
     });
-  }
-
-  private handleError(error: HttpErrorResponse): Observable<never> {
-    console.error(error);
-    let errorMessage = '';
-
-    if (error.status === 0) {
-      // An unknown server-side or network issue occurred
-      errorMessage =
-        'An unexpected error occurred. The server may be down or there may be network issues. Please try again later.';
-    } else if (this.isRecipeError(error.error)) {
-      // Use the error property sent by the server
-      // error.error is the raw HTTP response body
-      errorMessage = error.error.error; // lol
-    } else {
-      // Use the built-in error message for all other kinds of errors
-      errorMessage = error.message;
-    }
-
-    // Return an observable with a user-facing error message.
-    return throwError(() => new Error(errorMessage));
-  }
-
-  // Type guard to check if the server returned a valid error response
-  private isRecipeError(error: unknown): error is RecipeError {
-    // Assert that error is an object: https://stackoverflow.com/a/8511350
-    if (typeof error !== 'object' || Array.isArray(error) || error === null) {
-      return false;
-    }
-
-    return Object.prototype.hasOwnProperty.call(error, 'error');
   }
 
   private authHeader(token: string) {

--- a/src/app/services/terms.service.spec.ts
+++ b/src/app/services/terms.service.spec.ts
@@ -25,7 +25,9 @@ describe('TermsService', () => {
 
   const baseUrl = `${environment.serverBaseUrl}${Constants.termsPath}`;
   const mockError = new ProgressEvent('error');
-  const mockErrorMessage = `Http failure response for ${baseUrl}: 0 `;
+  const mockErrorMessage =
+    'An unexpected error occurred. The server may be down or there may be network issues. ' +
+    'Please try again later.';
   const localStorageProto = Object.getPrototypeOf(localStorage);
 
   beforeEach(() => {

--- a/src/app/services/terms.service.ts
+++ b/src/app/services/terms.service.ts
@@ -1,12 +1,13 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { Observable, catchError, of, throwError } from 'rxjs';
+import { Observable, catchError, of } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
 import Term from '../models/term.model';
 import { mockTerms } from '../models/term.mock';
 import Constants from '../constants/constants';
 import TermStore from '../models/term-store.model';
+import handleError from '../helpers/handleError';
 
 @Injectable({
   providedIn: 'root',
@@ -23,12 +24,7 @@ export class TermsService {
 
     return this.http
       .get<Term[]>(`${environment.serverBaseUrl}${Constants.termsPath}`)
-      .pipe(catchError(this.handleError.bind(this)));
-  }
-
-  private handleError(error: HttpErrorResponse): Observable<never> {
-    console.error(error);
-    return throwError(() => new Error(error.message));
+      .pipe(catchError(handleError));
   }
 
   // localStorage methods


### PR DESCRIPTION
![login-demo](https://github.com/user-attachments/assets/d8070a57-91a2-4c44-8f8a-5a27bf828e2a)

_The (partial) web implementation of https://github.com/Abhiek187/ez-recipes-web/issues/312, https://github.com/Abhiek187/ez-recipes-web/issues/7, & https://github.com/Abhiek187/ez-recipes-web/issues/6_

I used `localStorage` to handle saving the ID token and modified all the auth logic to incorporate this when checking if the user is authenticated, including the auth guard. The login and logout flows are working. I'll test the rest of the flows once I'm able to delete the account.

I also added snackbar messages whenever the user redirects from an email. Once we're ready to expose the profile tab, this means mobile users should no longer get a 404 page if they can't deep link into the mobile apps. So at least they'll still get some confirmation that the action was completed successfully.

I started writing tests for the profile component, but since these take longer than intended (not to mention all the components I need to test), I'll create the PR now and add the tests later once they're ready. (**Edit:** Didn't realize I set myself up to add all the other tests before I can merge this PR. 😅)