### PR TITLE
Profile Pt 4: Full CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Chefs can either find a random recipe or search for one using various filters, i
 
 The app features a glossary to easily look up the meaning of common terms found in recipes. This will better assist newer chefs in learning how to cook, prep certain ingredients, and use certain kitchen tools. Think [How to Stock](https://github.com/Abhiek187/how-to-stock), but for cooking food instead of managing finances.
 
+Creating an account is free and unlocks more exciting features for chefs. This includes favoriting, rating, and syncing recipes across the web and mobile apps. For example, chefs can browse recipes on the web app and open them on the mobile app to cook them in the kitchen.
+
 The site can be visited at https://ez-recipes-web.onrender.com/.
 
 ## Features
@@ -31,6 +33,7 @@ The site can be visited at https://ez-recipes-web.onrender.com/.
 - Best practices for Progressive Web Apps
 - Search Engine Optimization (SEO)
 - REST APIs to a custom [server](https://github.com/Abhiek187/ez-recipes-server), which fetches recipe information from [spoonacular](https://spoonacular.com/food-api) and MongoDB
+- Account management using Firebase Authentication
 - Offline data storage using localStorage and IndexedDB
 - Automated testing and deployment using CI/CD pipelines in GitHub Actions
 - Containerized development and production environments using Docker

--- a/src/app/components/profile/delete-account/delete-account.component.html
+++ b/src/app/components/profile/delete-account/delete-account.component.html
@@ -1,1 +1,35 @@
-<p>delete-account works!</p>
+<form
+  class="delete-account-form"
+  [formGroup]="formGroup"
+  (ngSubmit)="deleteAccount()"
+>
+  <h1>Are You Sure?</h1>
+  <h2>You will lose access to your favorite recipes.</h2>
+  <h3>Enter your username to confirm.</h3>
+  <mat-form-field>
+    <mat-label>Username</mat-label>
+    <input
+      matInput
+      [formControlName]="formControls.username"
+      type="email"
+      inputmode="email"
+      autocapitalize="none"
+      autocomplete="off"
+      spellcheck="false"
+    />
+  </mat-form-field>
+
+  <span class="submit-row">
+    <button
+      mat-raised-button
+      color="warn"
+      type="submit"
+      [disabled]="!formGroup.valid || isLoading()"
+    >
+      Delete Account
+    </button>
+    @if (isLoading()) {
+    <mat-spinner diameter="40" class="progress-spinner" />
+    }
+  </span>
+</form>

--- a/src/app/components/profile/delete-account/delete-account.component.scss
+++ b/src/app/components/profile/delete-account/delete-account.component.scss
@@ -13,6 +13,6 @@
 
   .progress-spinner {
     position: absolute;
-    margin-left: calc(73.4px + 16px);
+    margin-left: calc(145px + 16px);
   }
 }

--- a/src/app/components/profile/delete-account/delete-account.component.scss
+++ b/src/app/components/profile/delete-account/delete-account.component.scss
@@ -1,0 +1,18 @@
+.delete-account-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 16px;
+}
+
+.submit-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 32px;
+
+  .progress-spinner {
+    position: absolute;
+    margin-left: calc(73.4px + 16px);
+  }
+}

--- a/src/app/components/profile/delete-account/delete-account.component.spec.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.spec.ts
@@ -1,23 +1,104 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { DeleteAccountComponent } from './delete-account.component';
+import { mockChef } from 'src/app/models/profile.mock';
+import { ChefService } from 'src/app/services/chef.service';
+import { routes } from 'src/app/app-routing.module';
 
 describe('DeleteAccountComponent', () => {
-  let component: DeleteAccountComponent;
+  let deleteAccountComponent: DeleteAccountComponent;
   let fixture: ComponentFixture<DeleteAccountComponent>;
+  let rootElement: HTMLElement;
+  let router: Router;
+  let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [DeleteAccountComponent]
-    })
-    .compileComponents();
+    mockChefService = jasmine.createSpyObj('ChefService', [
+      'getChef',
+      'deleteChef',
+    ]);
+    mockChefService.getChef.and.returnValue(of(mockChef));
 
+    await TestBed.configureTestingModule({
+      imports: [DeleteAccountComponent],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        {
+          provide: ChefService,
+          useValue: mockChefService,
+        },
+      ],
+    }).compileComponents();
+
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => {});
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
+
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(DeleteAccountComponent);
-    component = fixture.componentInstance;
+    deleteAccountComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(deleteAccountComponent).toBeTruthy();
+    expect(rootElement.textContent).toContain('Are You Sure?');
+    expect(rootElement.textContent).toContain('Username');
+    expect(rootElement.textContent).toContain('Delete Account');
+
+    const usernameField = rootElement.querySelector<HTMLInputElement>('input');
+    expect(usernameField?.type).toBe('email');
+    expect(usernameField?.inputMode).toBe('email');
+    expect(usernameField?.autocapitalize).toBe('none');
+    expect(usernameField?.autocomplete).toBe('off');
+    expect(usernameField?.spellcheck).toBeFalse();
+  });
+
+  it("should disable account deletion if the username doesn't match", () => {
+    const form = deleteAccountComponent.formGroup;
+    form.controls.username.setValue('mock chef');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.username.hasError(
+        deleteAccountComponent.formErrors.usernameMismatch
+      )
+    ).toBeTrue();
+
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should enable account deletion if the username matches', () => {
+    const form = deleteAccountComponent.formGroup;
+    form.controls.username.setValue(mockChef.email);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeFalse();
+
+    mockChefService.deleteChef.and.returnValue(of(null));
+    const navigateSpy = spyOn(router, 'navigate');
+    submitButton?.click();
+    fixture.detectChanges();
+
+    expect(mockChefService.deleteChef).toHaveBeenCalledWith(mockChef.token);
+    expect(navigateSpy).toHaveBeenCalledWith([routes.profile.path]);
   });
 });

--- a/src/app/components/profile/delete-account/delete-account.component.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.ts
@@ -1,11 +1,120 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  inject,
+  OnDestroy,
+  OnInit,
+  Signal,
+  signal,
+} from '@angular/core';
+import {
+  ReactiveFormsModule,
+  FormGroup,
+  FormControl,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+
+import Constants from 'src/app/constants/constants';
+import { ChefService } from 'src/app/services/chef.service';
+import { routes } from 'src/app/app-routing.module';
+
+const formControls = {
+  username: 'username',
+} as const;
+const formErrors = {
+  usernameMismatch: 'usernameMismatch',
+} as const;
+
+const usernamesMatchValidator =
+  (chefUsername: Signal<string | null>): ValidatorFn =>
+  (control) => {
+    const username = control.value;
+
+    return username !== null &&
+      chefUsername() !== null &&
+      username !== chefUsername()
+      ? {
+          [formErrors.usernameMismatch]: true,
+        }
+      : null;
+  };
 
 @Component({
   selector: 'app-delete-account',
-  imports: [],
+  imports: [
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    ReactiveFormsModule,
+  ],
   templateUrl: './delete-account.component.html',
-  styleUrl: './delete-account.component.scss'
+  styleUrl: './delete-account.component.scss',
 })
-export class DeleteAccountComponent {
+export class DeleteAccountComponent implements OnInit, OnDestroy {
+  private chefService = inject(ChefService);
+  private snackBar = inject(MatSnackBar);
+  private router = inject(Router);
 
+  private chefServiceSubscription?: Subscription;
+
+  isLoading = signal(false);
+  private chefUsername = signal<string | null>(null);
+
+  formControls = formControls;
+  formErrors = formErrors;
+  formGroup = new FormGroup({
+    [formControls.username]: new FormControl('', [
+      Validators.required,
+      usernamesMatchValidator(this.chefUsername),
+    ]),
+  });
+
+  ngOnInit(): void {
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) return;
+
+    this.chefService.getChef(token).subscribe({
+      next: ({ email }) => {
+        this.chefUsername.set(email);
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.chefServiceSubscription?.unsubscribe();
+  }
+
+  deleteAccount() {
+    this.isLoading.set(true);
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      this.isLoading.set(false);
+      this.snackBar.open(Constants.noTokenFound, 'Dismiss');
+      return;
+    }
+
+    this.chefServiceSubscription = this.chefService
+      .deleteChef(token)
+      .subscribe({
+        next: () => {
+          this.isLoading.set(false);
+
+          localStorage.removeItem(Constants.LocalStorage.token);
+          this.snackBar.open('Your account has been deleted.', 'Dismiss');
+          this.router.navigate([routes.profile.path]);
+        },
+        error: (error) => {
+          this.isLoading.set(false);
+          this.snackBar.open(error.message, 'Dismiss');
+        },
+      });
+  }
 }

--- a/src/app/components/profile/delete-account/delete-account.component.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.ts
@@ -29,6 +29,7 @@ const formControls = {
   username: 'username',
 } as const;
 const formErrors = {
+  required: 'required',
   usernameMismatch: 'usernameMismatch',
 } as const;
 
@@ -78,14 +79,10 @@ export class DeleteAccountComponent implements OnInit, OnDestroy {
   });
 
   ngOnInit(): void {
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token === null) return;
-
-    this.chefService.getChef(token).subscribe({
-      next: ({ email }) => {
-        this.chefUsername.set(email);
-      },
-    });
+    const email = this.router.lastSuccessfulNavigation?.extras?.state?.email;
+    if (typeof email === 'string') {
+      this.chefUsername.set(email);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/components/profile/forgot-password/forgot-password.component.scss
+++ b/src/app/components/profile/forgot-password/forgot-password.component.scss
@@ -16,6 +16,6 @@
 
   .progress-spinner {
     position: absolute;
-    margin-left: calc(73.4px + 16px);
+    margin-left: calc(84px + 16px);
   }
 }

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -121,6 +121,8 @@ describe('LoginComponent', () => {
     expect(mockChefService.verifyEmail).toHaveBeenCalledWith(
       mockLoginResponse(false).token
     );
-    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path]);
+    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path], {
+      state: { email: mockEmail },
+    });
   });
 });

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -85,13 +85,18 @@ export class LoginComponent implements OnDestroy {
           if (!emailVerified) {
             // Don't update the chef's verified status until they click the redirect link
             this.chefService.verifyEmail(token).subscribe();
-            this.router.navigate([profileRoutes.verifyEmail.path]);
+            this.router.navigate([profileRoutes.verifyEmail.path], {
+              state: { email: username },
+            });
           } else {
             // If a redirect URL is present in the query params, navigate to it
             // Otherwise, navigate to the profile page
             const redirectUrl = this.route.snapshot.queryParamMap.get('next');
             if (redirectUrl !== null) {
-              this.router.navigateByUrl(redirectUrl);
+              this.router.navigateByUrl(redirectUrl, {
+                // Several pages require the chef's email
+                state: { email: username },
+              });
             } else {
               this.router.navigate([routes.profile.path]);
             }

--- a/src/app/components/profile/profile.component.spec.ts
+++ b/src/app/components/profile/profile.component.spec.ts
@@ -104,13 +104,23 @@ describe('ProfileComponent', () => {
     changeEmailButton.click();
     expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.updateEmail.path]);
     changePasswordButton.click();
-    expect(navigateSpy).toHaveBeenCalledWith([
-      profileRoutes.updatePassword.path,
-    ]);
+    expect(navigateSpy).toHaveBeenCalledWith(
+      [profileRoutes.updatePassword.path],
+      {
+        state: {
+          email: mockChef.email,
+        },
+      }
+    );
     deleteAccountButton.click();
-    expect(navigateSpy).toHaveBeenCalledWith([
-      profileRoutes.deleteAccount.path,
-    ]);
+    expect(navigateSpy).toHaveBeenCalledWith(
+      [profileRoutes.deleteAccount.path],
+      {
+        state: {
+          email: mockChef.email,
+        },
+      }
+    );
 
     logoutButton.click();
     fixture.detectChanges();

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -110,10 +110,18 @@ export class ProfileComponent implements OnInit {
   }
 
   changePassword() {
-    this.router.navigate([profileRoutes.updatePassword.path]);
+    this.router.navigate([profileRoutes.updatePassword.path], {
+      state: {
+        email: this.chef()?.email,
+      },
+    });
   }
 
   deleteAccount() {
-    this.router.navigate([profileRoutes.deleteAccount.path]);
+    this.router.navigate([profileRoutes.deleteAccount.path], {
+      state: {
+        email: this.chef()?.email,
+      },
+    });
   }
 }

--- a/src/app/components/profile/sign-up/sign-up.component.scss
+++ b/src/app/components/profile/sign-up/sign-up.component.scss
@@ -19,6 +19,6 @@
 
   .progress-spinner {
     position: absolute;
-    margin-left: calc(73.4px + 16px);
+    margin-left: calc(89px + 16px);
   }
 }

--- a/src/app/components/profile/sign-up/sign-up.component.spec.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.spec.ts
@@ -195,6 +195,8 @@ describe('SignUpComponent', () => {
     expect(mockChefService.verifyEmail).toHaveBeenCalledWith(
       mockLoginResponse(false).token
     );
-    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path]);
+    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path], {
+      state: { email: mockEmail },
+    });
   });
 });

--- a/src/app/components/profile/sign-up/sign-up.component.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.ts
@@ -134,11 +134,15 @@ export class SignUpComponent implements OnDestroy {
           if (!emailVerified) {
             // Should always be true
             this.chefService.verifyEmail(token).subscribe();
-            this.router.navigate([profileRoutes.verifyEmail.path]);
+            this.router.navigate([profileRoutes.verifyEmail.path], {
+              state: { email },
+            });
           } else {
             const redirectUrl = this.route.snapshot.queryParamMap.get('next');
             if (redirectUrl !== null) {
-              this.router.navigateByUrl(redirectUrl);
+              this.router.navigateByUrl(redirectUrl, {
+                state: { email },
+              });
             } else {
               this.router.navigate([routes.profile.path]);
             }

--- a/src/app/components/profile/update-email/update-email.component.html
+++ b/src/app/components/profile/update-email/update-email.component.html
@@ -1,1 +1,45 @@
-<p>update-email works!</p>
+@if (emailSent()) {
+<h3 class="update-email-confirm">
+  We sent an email to <b>{{ formGroup.controls.email.value }}</b
+  >. Follow the instructions to change your email.
+</h3>
+} @else {
+<form
+  class="update-email-form"
+  [formGroup]="formGroup"
+  (ngSubmit)="updateEmail()"
+>
+  <h1>Change Email</h1>
+  <mat-form-field>
+    <mat-label>New Email</mat-label>
+    <input
+      matInput
+      [formControlName]="formControls.email"
+      type="email"
+      inputmode="email"
+      autocapitalize="none"
+      autocomplete="off"
+      spellcheck="false"
+    />
+    @if (formGroup.controls.email.hasError(formErrors.required)) {
+    <mat-error>{{ errors.required }}</mat-error>
+    } @else if (formGroup.controls.email.hasError(formErrors.emailInvalid)) {
+    <mat-error>{{ errors.email }}</mat-error>
+    }
+  </mat-form-field>
+
+  <span class="submit-row">
+    <button
+      mat-raised-button
+      color="accent"
+      type="submit"
+      [disabled]="!formGroup.valid || isLoading()"
+    >
+      Submit
+    </button>
+    @if (isLoading()) {
+    <mat-spinner diameter="40" class="progress-spinner" />
+    }
+  </span>
+</form>
+}

--- a/src/app/components/profile/update-email/update-email.component.scss
+++ b/src/app/components/profile/update-email/update-email.component.scss
@@ -17,6 +17,6 @@
 
   .progress-spinner {
     position: absolute;
-    margin-left: calc(73.4px + 16px);
+    margin-left: calc(84px + 16px);
   }
 }

--- a/src/app/components/profile/update-email/update-email.component.scss
+++ b/src/app/components/profile/update-email/update-email.component.scss
@@ -1,0 +1,22 @@
+.update-email-confirm,
+.update-email-form {
+  margin: 16px;
+}
+
+.update-email-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.submit-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 32px;
+
+  .progress-spinner {
+    position: absolute;
+    margin-left: calc(73.4px + 16px);
+  }
+}

--- a/src/app/components/profile/update-email/update-email.component.spec.ts
+++ b/src/app/components/profile/update-email/update-email.component.spec.ts
@@ -1,23 +1,119 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { UpdateEmailComponent } from './update-email.component';
+import { ChefService } from 'src/app/services/chef.service';
+import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
+import { ChefUpdateType } from 'src/app/models/profile.model';
 
 describe('UpdateEmailComponent', () => {
-  let component: UpdateEmailComponent;
+  let updateEmailComponent: UpdateEmailComponent;
   let fixture: ComponentFixture<UpdateEmailComponent>;
+  let rootElement: HTMLElement;
+  let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
+    mockChefService = jasmine.createSpyObj('ChefService', ['updateChef']);
+
     await TestBed.configureTestingModule({
-      imports: [UpdateEmailComponent]
-    })
-    .compileComponents();
+      imports: [UpdateEmailComponent],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        {
+          provide: ChefService,
+          useValue: mockChefService,
+        },
+      ],
+    }).compileComponents();
+
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => {});
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
 
     fixture = TestBed.createComponent(UpdateEmailComponent);
-    component = fixture.componentInstance;
+    updateEmailComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(updateEmailComponent).toBeTruthy();
+    expect(rootElement.textContent).toContain('Change Email');
+    expect(rootElement.textContent).toContain('New Email');
+    expect(rootElement.textContent).toContain('Submit');
+
+    const emailField = rootElement.querySelector<HTMLInputElement>('input');
+    expect(emailField?.type).toBe('email');
+    expect(emailField?.inputMode).toBe('email');
+    expect(emailField?.autocapitalize).toBe('none');
+    expect(emailField?.autocomplete).toBe('off');
+    expect(emailField?.spellcheck).toBeFalse();
+  });
+
+  it("should show an error if the email isn't provided", () => {
+    const form = updateEmailComponent.formGroup;
+    form.controls.email.setValue(null);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.email.hasError(updateEmailComponent.formErrors.required)
+    ).toBeTrue();
+
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it("should show an error if the email isn't valid", () => {
+    const form = updateEmailComponent.formGroup;
+    form.controls.email.setValue('not an email');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.email.hasError(updateEmailComponent.formErrors.emailInvalid)
+    ).toBeTrue();
+
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should enable the submit button if the email is valid', () => {
+    const form = updateEmailComponent.formGroup;
+    const mockEmail = 'test@example.com';
+    form.controls.email.setValue(mockEmail);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeFalse();
+
+    mockChefService.updateChef.and.returnValue(of(mockChefEmailResponse));
+    submitButton?.click();
+    fixture.detectChanges();
+
+    expect(mockChefService.updateChef).toHaveBeenCalledWith(
+      {
+        type: ChefUpdateType.Email,
+        email: mockEmail,
+      },
+      mockChef.token
+    );
+    expect(rootElement.textContent).toContain(
+      `We sent an email to ${mockEmail}`
+    );
   });
 });

--- a/src/app/components/profile/update-email/update-email.component.ts
+++ b/src/app/components/profile/update-email/update-email.component.ts
@@ -1,11 +1,93 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnDestroy, signal } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Subscription } from 'rxjs';
+
+import Constants from 'src/app/constants/constants';
+import { ChefUpdate, ChefUpdateType } from 'src/app/models/profile.model';
+import { ChefService } from 'src/app/services/chef.service';
 
 @Component({
   selector: 'app-update-email',
-  imports: [],
+  imports: [
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    ReactiveFormsModule,
+  ],
   templateUrl: './update-email.component.html',
-  styleUrl: './update-email.component.scss'
+  styleUrl: './update-email.component.scss',
 })
-export class UpdateEmailComponent {
+export class UpdateEmailComponent implements OnDestroy {
+  private chefService = inject(ChefService);
+  private snackBar = inject(MatSnackBar);
 
+  private chefServiceSubscription?: Subscription;
+
+  isLoading = signal(false);
+  emailSent = signal(false);
+
+  readonly formControls = {
+    email: 'email',
+  } as const;
+  readonly formErrors = {
+    required: 'required',
+    emailInvalid: 'email',
+  } as const;
+  formGroup = new FormGroup({
+    [this.formControls.email]: new FormControl('', [
+      Validators.required,
+      Validators.email,
+    ]),
+  });
+  readonly errors = {
+    [this.formErrors.required]: 'Error: email is required',
+    [this.formErrors.emailInvalid]: 'Error: Invalid email',
+  } as const;
+
+  ngOnDestroy(): void {
+    this.chefServiceSubscription?.unsubscribe();
+  }
+
+  updateEmail() {
+    this.isLoading.set(true);
+    const { email } = this.formGroup.value;
+    const fields: ChefUpdate = {
+      type: ChefUpdateType.Email,
+      email: email ?? '',
+    };
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      this.isLoading.set(false);
+      this.snackBar.open(Constants.noTokenFound, 'Dismiss');
+      return;
+    }
+
+    this.chefServiceSubscription = this.chefService
+      .updateChef(fields, token)
+      .subscribe({
+        next: ({ token }) => {
+          this.isLoading.set(false);
+          this.emailSent.set(true);
+
+          if (token !== undefined) {
+            localStorage.setItem(Constants.LocalStorage.token, token);
+          }
+        },
+        error: (error) => {
+          this.isLoading.set(false);
+          this.snackBar.open(error.message, 'Dismiss');
+        },
+      });
+  }
 }

--- a/src/app/components/profile/update-password/update-password.component.html
+++ b/src/app/components/profile/update-password/update-password.component.html
@@ -1,1 +1,78 @@
-<p>update-password works!</p>
+<form
+  class="update-password-form"
+  [formGroup]="formGroup"
+  (ngSubmit)="updatePassword()"
+>
+  <h1>Change Password</h1>
+  <div class="password-fields">
+    <mat-form-field>
+      <mat-label>New Password</mat-label>
+      <input
+        matInput
+        [formControlName]="formControls.password"
+        [type]="showPassword() ? 'text' : 'password'"
+        autocapitalize="none"
+        autocomplete="off"
+        spellcheck="false"
+      />
+      <button
+        mat-icon-button
+        matSuffix
+        (click)="togglePasswordVisibility($event)"
+        [attr.aria-label]="showPassword() ? 'Hide password' : 'Show password'"
+      >
+        <mat-icon>{{
+          showPassword() ? "visibility_off" : "visibility"
+        }}</mat-icon>
+      </button>
+      @if (formGroup.controls.password.hasError(formErrors.required)) {
+      <mat-error>{{ errors.required }}</mat-error>
+      } @else if
+      (formGroup.controls.password.hasError(formErrors.passwordMinLength)) {
+      <mat-error>{{ errors.minlength }}</mat-error>
+      }
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Confirm Password</mat-label>
+      <input
+        matInput
+        [formControlName]="formControls.passwordConfirm"
+        [type]="showPasswordConfirm() ? 'text' : 'password'"
+        autocapitalize="none"
+        autocomplete="off"
+        spellcheck="false"
+      />
+      <button
+        mat-icon-button
+        matSuffix
+        (click)="togglePasswordConfirmVisibility($event)"
+        [attr.aria-label]="
+          showPasswordConfirm() ? 'Hide password' : 'Show password'
+        "
+      >
+        <mat-icon>{{
+          showPasswordConfirm() ? "visibility_off" : "visibility"
+        }}</mat-icon>
+      </button>
+      @if (formGroup.hasError(formErrors.passwordMismatch)) {
+      <mat-error>{{ errors.passwordMismatch }}</mat-error>
+      } @else {
+      <mat-hint>Password must be at least 8 characters long</mat-hint>
+      }
+    </mat-form-field>
+  </div>
+
+  <span class="submit-row">
+    <button
+      mat-raised-button
+      color="accent"
+      type="submit"
+      [disabled]="!formGroup.valid || isLoading()"
+    >
+      Submit
+    </button>
+    @if (isLoading()) {
+    <mat-spinner diameter="40" class="progress-spinner" />
+    }
+  </span>
+</form>

--- a/src/app/components/profile/update-password/update-password.component.scss
+++ b/src/app/components/profile/update-password/update-password.component.scss
@@ -1,0 +1,24 @@
+.update-password-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 16px;
+}
+
+.password-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.submit-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 32px;
+
+  .progress-spinner {
+    position: absolute;
+    margin-left: calc(73.4px + 16px);
+  }
+}

--- a/src/app/components/profile/update-password/update-password.component.scss
+++ b/src/app/components/profile/update-password/update-password.component.scss
@@ -19,6 +19,6 @@
 
   .progress-spinner {
     position: absolute;
-    margin-left: calc(73.4px + 16px);
+    margin-left: calc(84px + 16px);
   }
 }

--- a/src/app/components/profile/update-password/update-password.component.spec.ts
+++ b/src/app/components/profile/update-password/update-password.component.spec.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { Router, UrlTree } from '@angular/router';
 import { of } from 'rxjs';
 
 import { UpdatePasswordComponent } from './update-password.component';
@@ -21,11 +21,7 @@ describe('UpdatePasswordComponent', () => {
   let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
-    mockChefService = jasmine.createSpyObj('ChefService', [
-      'getChef',
-      'updateChef',
-    ]);
-    mockChefService.getChef.and.returnValue(of(mockChef));
+    mockChefService = jasmine.createSpyObj('ChefService', ['updateChef']);
 
     await TestBed.configureTestingModule({
       imports: [UpdatePasswordComponent],
@@ -45,6 +41,15 @@ describe('UpdatePasswordComponent', () => {
     spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
 
     router = TestBed.inject(Router);
+    spyOnProperty(router, 'lastSuccessfulNavigation').and.returnValue({
+      extras: { state: { email: mockChef.email } },
+      id: 0,
+      initialUrl: new UrlTree(),
+      extractedUrl: new UrlTree(),
+      trigger: 'imperative',
+      previousNavigation: null,
+      abort: () => {},
+    });
     fixture = TestBed.createComponent(UpdatePasswordComponent);
     updatePasswordComponent = fixture.componentInstance;
     rootElement = fixture.nativeElement;

--- a/src/app/components/profile/update-password/update-password.component.spec.ts
+++ b/src/app/components/profile/update-password/update-password.component.spec.ts
@@ -1,4 +1,3 @@
-import { UpdatePasswordComponent } from './update-password.component';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
@@ -8,6 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
 
+import { UpdatePasswordComponent } from './update-password.component';
 import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
 import { ChefUpdateType } from 'src/app/models/profile.model';
 import { ChefService } from 'src/app/services/chef.service';

--- a/src/app/components/profile/update-password/update-password.component.spec.ts
+++ b/src/app/components/profile/update-password/update-password.component.spec.ts
@@ -1,23 +1,173 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { UpdatePasswordComponent } from './update-password.component';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
+import { ChefUpdateType } from 'src/app/models/profile.model';
+import { ChefService } from 'src/app/services/chef.service';
+import { profileRoutes } from 'src/app/app-routing.module';
 
 describe('UpdatePasswordComponent', () => {
-  let component: UpdatePasswordComponent;
+  let updatePasswordComponent: UpdatePasswordComponent;
   let fixture: ComponentFixture<UpdatePasswordComponent>;
+  let rootElement: HTMLElement;
+  let router: Router;
+  let mockChefService: jasmine.SpyObj<ChefService>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [UpdatePasswordComponent]
-    })
-    .compileComponents();
+    mockChefService = jasmine.createSpyObj('ChefService', [
+      'getChef',
+      'updateChef',
+    ]);
+    mockChefService.getChef.and.returnValue(of(mockChef));
 
+    await TestBed.configureTestingModule({
+      imports: [UpdatePasswordComponent],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        {
+          provide: ChefService,
+          useValue: mockChefService,
+        },
+      ],
+    }).compileComponents();
+
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => {});
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
+
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(UpdatePasswordComponent);
-    component = fixture.componentInstance;
+    updatePasswordComponent = fixture.componentInstance;
+    rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(updatePasswordComponent).toBeTruthy();
+    expect(rootElement.textContent).toContain('Change Password');
+    expect(rootElement.textContent).toContain('New Password');
+    expect(rootElement.textContent).toContain('Confirm Password');
+    expect(rootElement.textContent).toContain(
+      'Password must be at least 8 characters long'
+    );
+    expect(rootElement.textContent).toContain('Submit');
+
+    const signUpFields = rootElement.querySelector('.password-fields');
+    const [passwordField, confirmPasswordField] = Array.from(
+      signUpFields?.querySelectorAll<HTMLInputElement>('input') ?? []
+    );
+
+    expect(passwordField.type).toBe('password');
+    expect(passwordField.autocapitalize).toBe('none');
+    expect(passwordField.autocomplete).toBe('off');
+    expect(passwordField.spellcheck).toBeFalse();
+
+    expect(confirmPasswordField.type).toBe('password');
+    expect(confirmPasswordField.autocapitalize).toBe('none');
+    expect(confirmPasswordField.autocomplete).toBe('off');
+    expect(confirmPasswordField.spellcheck).toBeFalse();
+
+    updatePasswordComponent.showPassword.set(true);
+    fixture.detectChanges();
+    expect(passwordField.type).toBe('text');
+    updatePasswordComponent.showPassword.set(false);
+    fixture.detectChanges();
+    expect(passwordField.type).toBe('password');
+
+    updatePasswordComponent.showPasswordConfirm.set(true);
+    fixture.detectChanges();
+    expect(confirmPasswordField.type).toBe('text');
+    updatePasswordComponent.showPasswordConfirm.set(false);
+    fixture.detectChanges();
+    expect(confirmPasswordField.type).toBe('password');
+  });
+
+  it("should show an error if the password isn't provided", () => {
+    const form = updatePasswordComponent.formGroup;
+    form.controls.password.setValue(null);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.password.hasError(
+        updatePasswordComponent.formErrors.required
+      )
+    ).toBeTrue();
+
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should show an error if the password is too short', () => {
+    const form = updatePasswordComponent.formGroup;
+    form.controls.password.setValue('123');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.controls.password.hasError(
+        updatePasswordComponent.formErrors.passwordMinLength
+      )
+    ).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it("should show an error if the passwords don't match", () => {
+    const form = updatePasswordComponent.formGroup;
+    form.controls.password.setValue('password1');
+    form.controls.passwordConfirm.setValue('password2');
+    fixture.detectChanges();
+
+    expect(form.valid).toBeFalse();
+    expect(
+      form.hasError(updatePasswordComponent.formErrors.passwordMismatch)
+    ).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeTrue();
+  });
+
+  it('should enable the submit button if the email is valid', () => {
+    const form = updatePasswordComponent.formGroup;
+    const mockPassword = 'password123';
+    form.controls.password.setValue(mockPassword);
+    form.controls.passwordConfirm.setValue(mockPassword);
+    fixture.detectChanges();
+
+    expect(form.valid).toBeTrue();
+    const submitButton = rootElement
+      .querySelector('.submit-row')
+      ?.querySelector('button');
+    expect(submitButton?.disabled).toBeFalse();
+
+    mockChefService.updateChef.and.returnValue(of(mockChefEmailResponse));
+    const navigateSpy = spyOn(router, 'navigate');
+    submitButton?.click();
+    fixture.detectChanges();
+
+    expect(mockChefService.updateChef).toHaveBeenCalledWith(
+      {
+        type: ChefUpdateType.Password,
+        email: mockChef.email,
+        password: mockPassword,
+      },
+      mockChef.token
+    );
+    expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.login.path]);
   });
 });

--- a/src/app/components/profile/update-password/update-password.component.ts
+++ b/src/app/components/profile/update-password/update-password.component.ts
@@ -1,11 +1,154 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import {
+  ReactiveFormsModule,
+  FormGroup,
+  FormControl,
+  Validators,
+  ValidatorFn,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+
+import Constants from 'src/app/constants/constants';
+import { ChefUpdate, ChefUpdateType } from 'src/app/models/profile.model';
+import { ChefService } from 'src/app/services/chef.service';
+import { profileRoutes } from 'src/app/app-routing.module';
+
+const formControls = {
+  password: 'password',
+  passwordConfirm: 'passwordConfirm',
+} as const;
+const formErrors = {
+  required: 'required',
+  passwordMinLength: 'minlength',
+  passwordMismatch: 'passwordMismatch',
+} as const;
+
+const passwordsMatchValidator: ValidatorFn = (control) => {
+  const password = control.get(formControls.password);
+  const passwordConfirm = control.get(formControls.passwordConfirm);
+
+  const error =
+    password?.value !== null &&
+    passwordConfirm?.value !== null &&
+    password?.value !== passwordConfirm?.value
+      ? {
+          [formErrors.passwordMismatch]: true,
+        }
+      : null;
+  passwordConfirm?.setErrors(error);
+  return error;
+};
 
 @Component({
   selector: 'app-update-password',
-  imports: [],
+  imports: [
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    ReactiveFormsModule,
+  ],
   templateUrl: './update-password.component.html',
-  styleUrl: './update-password.component.scss'
+  styleUrl: './update-password.component.scss',
 })
-export class UpdatePasswordComponent {
+export class UpdatePasswordComponent implements OnInit, OnDestroy {
+  private chefService = inject(ChefService);
+  private snackBar = inject(MatSnackBar);
+  private router = inject(Router);
 
+  private chefServiceSubscription?: Subscription;
+
+  showPassword = signal(false);
+  showPasswordConfirm = signal(false);
+  isLoading = signal(false);
+  private chefEmail = signal('');
+
+  formControls = formControls;
+  formErrors = formErrors;
+  formGroup = new FormGroup(
+    {
+      [formControls.password]: new FormControl('', [
+        Validators.required,
+        Validators.minLength(Constants.passwordMinLength),
+      ]),
+      [formControls.passwordConfirm]: new FormControl('', [
+        Validators.required,
+      ]),
+    },
+    { validators: passwordsMatchValidator }
+  );
+  readonly errors = {
+    [formErrors.required]: 'Error: password is required',
+    [formErrors.passwordMinLength]: `Error: Password must be at least ${Constants.passwordMinLength} characters long`,
+    [formErrors.passwordMismatch]: 'Error: Passwords do not match',
+  } as const;
+
+  ngOnInit(): void {
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) return;
+
+    this.chefService.getChef(token).subscribe({
+      next: ({ email }) => {
+        this.chefEmail.set(email);
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.chefServiceSubscription?.unsubscribe();
+  }
+
+  togglePasswordVisibility(event: MouseEvent) {
+    event.preventDefault();
+    this.showPassword.set(!this.showPassword());
+  }
+
+  togglePasswordConfirmVisibility(event: MouseEvent) {
+    event.preventDefault();
+    this.showPasswordConfirm.set(!this.showPasswordConfirm());
+  }
+
+  updatePassword() {
+    this.isLoading.set(true);
+    const { password } = this.formGroup.value;
+    const fields: ChefUpdate = {
+      type: ChefUpdateType.Password,
+      email: this.chefEmail(),
+      password: password ?? '',
+    };
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      this.isLoading.set(false);
+      this.snackBar.open(Constants.noTokenFound, 'Dismiss');
+      return;
+    }
+
+    this.chefServiceSubscription = this.chefService
+      .updateChef(fields, token)
+      .subscribe({
+        next: () => {
+          this.isLoading.set(false);
+
+          // The token will be revoked, so sign out the user
+          localStorage.removeItem(Constants.LocalStorage.token);
+          this.snackBar.open(
+            'Password updated successfully! Please sign in again.',
+            'Dismiss'
+          );
+          this.router.navigate([profileRoutes.login.path]);
+        },
+        error: (error) => {
+          this.isLoading.set(false);
+          this.snackBar.open(error.message, 'Dismiss');
+        },
+      });
+  }
 }

--- a/src/app/components/profile/update-password/update-password.component.ts
+++ b/src/app/components/profile/update-password/update-password.component.ts
@@ -92,14 +92,10 @@ export class UpdatePasswordComponent implements OnInit, OnDestroy {
   } as const;
 
   ngOnInit(): void {
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token === null) return;
-
-    this.chefService.getChef(token).subscribe({
-      next: ({ email }) => {
-        this.chefEmail.set(email);
-      },
-    });
+    const email = this.router.lastSuccessfulNavigation?.extras?.state?.email;
+    if (typeof email === 'string') {
+      this.chefEmail.set(email);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/components/profile/verify-email/verify-email.component.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.ts
@@ -3,6 +3,7 @@ import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 
 import Constants from 'src/app/constants/constants';
@@ -17,6 +18,7 @@ import { routes } from 'src/app/app-routing.module';
 })
 export class VerifyEmailComponent implements OnInit {
   private chefService = inject(ChefService);
+  private snackBar = inject(MatSnackBar);
   private router = inject(Router);
 
   email = signal('...');
@@ -57,7 +59,11 @@ export class VerifyEmailComponent implements OnInit {
   resendVerificationEmail() {
     const token = localStorage.getItem(Constants.LocalStorage.token);
     if (token !== null) {
-      this.chefService.verifyEmail(token).subscribe();
+      this.chefService.verifyEmail(token).subscribe({
+        error: (error) => {
+          this.snackBar.open(error.message, 'Dismiss');
+        },
+      });
     }
     this.enableResend.set(false);
   }

--- a/src/app/components/profile/verify-email/verify-email.component.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -15,11 +15,11 @@ import { routes } from 'src/app/app-routing.module';
   templateUrl: './verify-email.component.html',
   styleUrl: './verify-email.component.scss',
 })
-export class VerifyEmailComponent {
+export class VerifyEmailComponent implements OnInit {
   private chefService = inject(ChefService);
   private router = inject(Router);
 
-  email = signal('test@example.com'); // TODO: replace with actual email
+  email = signal('...');
   // Throttle the number of times the user can resend the verification email to satisfy API limits
   enableResend = signal(false);
   secondsRemaining = signal(Constants.emailCooldownSeconds);
@@ -42,6 +42,16 @@ export class VerifyEmailComponent {
         }, 1000);
       }
     });
+  }
+
+  ngOnInit(): void {
+    /* State may not be available if navigating directly to this page,
+     * but the the guard functions should redirect the user in this case
+     */
+    const email = this.router.lastSuccessfulNavigation?.extras?.state?.email;
+    if (typeof email === 'string') {
+      this.email.set(email);
+    }
   }
 
   resendVerificationEmail() {

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -17,6 +17,7 @@ abstract class Constants {
     'Mixing things up... 🥘',
     'Shaking things up... 🍲',
   ];
+  static readonly noTokenFound = 'No token found';
 
   // APIs
   static readonly recipesPath = '/api/recipes';


### PR DESCRIPTION
## Sign Up

https://github.com/user-attachments/assets/74dd54fa-c703-4354-9b5c-19fa651c8624

## Forgot Password

https://github.com/user-attachments/assets/ac3d8e7a-03ce-4272-a219-ccdf1de904ed

## Change Password & Delete Account

https://github.com/user-attachments/assets/7818ab64-fde2-4878-851c-76401bb70b4b

https://github.com/user-attachments/assets/2e0f0445-8fa5-4cf4-b7ae-6c381afeed70

## Change Email

https://github.com/user-attachments/assets/03770a45-f635-4b46-ad9f-b648771efdfd

https://github.com/user-attachments/assets/90fa2c0d-8ed2-46ae-82a9-08c1ba3cf31a

_The web implementation of #6, #7, #312, & #362_

I added all the other forms we need on the profile page and was able to test the full end-to-end auth flow. Once I figured out how to efficiently pass state (i.e., the chef's email) when navigating between components (using the browser's history state), all the form and API logic worked as expected. Since we're testing locally, the continue URLs can't be fully tested, but I can modify the host to localhost:4200 and see the correct snackbar messages appear at the bottom. There was a lot of copy-pasting for all the forms and tests, so there might be a way to make everything more reusable, but for now, I'm glad it's all working!

I'm going to keep the dev guard on since we need to implement all the benefits mentioned when the user is signed out. This means I won't be able to fully test the site on mobile or with password managers (since localhost is shared with my other projects) until we go live.