### PR TITLE
Recipe Stats

### DIFF
--- a/src/app/components/glossary/glossary.component.html
+++ b/src/app/components/glossary/glossary.component.html
@@ -1,6 +1,6 @@
-@if (terms !== undefined) {
+@if (terms() !== undefined) {
 <mat-list>
-  @for (term of terms; track term._id) {
+  @for (term of terms(); track term._id) {
   <mat-list-item class="term-list">
     <span class="term-line">
       <b>{{ term.word }}</b> — {{ term.definition }}

--- a/src/app/components/glossary/glossary.component.spec.ts
+++ b/src/app/components/glossary/glossary.component.spec.ts
@@ -32,7 +32,7 @@ describe('GlossaryComponent', () => {
 
   it('should show all the terms', () => {
     expect(glossaryComponent).toBeTruthy();
-    expect(glossaryComponent.terms).not.toBeNull();
+    expect(glossaryComponent.terms()).not.toBeNull();
 
     for (const term of mockTerms) {
       expect(rootElement.textContent).toContain(term.word);

--- a/src/app/components/glossary/glossary.component.ts
+++ b/src/app/components/glossary/glossary.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatListModule } from '@angular/material/list';
 
@@ -14,14 +14,15 @@ import { TermsService } from 'src/app/services/terms.service';
 export class GlossaryComponent implements OnInit {
   private termsService = inject(TermsService);
 
-  terms?: Term[];
+  terms = signal<Term[] | undefined>(undefined);
 
   ngOnInit(): void {
-    this.terms = this.termsService.getCachedTerms()?.toSorted((a, b) => {
+    const sortedTerms = this.termsService.getCachedTerms()?.toSorted((a, b) => {
       // Sort all the terms alphabetically for ease of reference
       if (a.word < b.word) return -1;
       else if (a.word > b.word) return 1;
       else return 0;
     });
+    this.terms.set(sortedTerms);
   }
 }

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -5,21 +5,21 @@
     color="accent"
     class="find-recipe-button"
     (click)="getRandomRecipe()"
-    [disabled]="isLoading"
+    [disabled]="isLoading()"
   >
     Find Me a Recipe!
   </button>
 </div>
 
-@if (isLoading) {
+@if (isLoading()) {
 <mat-spinner diameter="50" class="progress-spinner" />
-<p class="loading-message">{{ loadingMessage }}</p>
-} @if (recentRecipes.length > 0) {
+<p class="loading-message">{{ loadingMessage() }}</p>
+} @if (recentRecipes().length > 0) {
 <section class="recents-section">
   <h1 class="recents-title">Recently Viewed</h1>
   <mat-divider />
   <ul class="recents-list">
-    @for (recipe of recentRecipes; track recipe.id) {
+    @for (recipe of recentRecipes(); track recipe.id) {
     <li>
       <app-recipe-card [recipe]="recipe" />
     </li>

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -77,7 +77,7 @@ describe('HomeComponent', () => {
     ).toBeDefined();
 
     // The spinner should be hidden
-    expect(homeComponent.isLoading).toBeFalse();
+    expect(homeComponent.isLoading()).toBeFalse();
     expect(rootElement.querySelector('.progress-spinner')).toBeNull();
   });
 
@@ -98,7 +98,7 @@ describe('HomeComponent', () => {
 
   it('should show a spinner while loading', () => {
     // Check that the material spinner shows when isLoading is true
-    homeComponent.isLoading = true;
+    homeComponent.isLoading.set(true);
     fixture.detectChanges();
 
     expect(rootElement.querySelector('.progress-spinner')).not.toBeNull();
@@ -114,9 +114,9 @@ describe('HomeComponent', () => {
     // The loading message should start blank, then show a random message after some time
     fixture.detectChanges();
     homeComponent.showLoadingMessages();
-    expect(homeComponent.loadingMessage).toBe('');
+    expect(homeComponent.loadingMessage()).toBe('');
     jasmine.clock().tick(3000);
-    expect(Constants.loadingMessages).toContain(homeComponent.loadingMessage);
+    expect(Constants.loadingMessages).toContain(homeComponent.loadingMessage());
   });
 
   it("shouldn't show the recents section if there aren't any recent recipes", () => {

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -61,17 +61,17 @@ export class HomeComponent implements OnInit, OnDestroy {
       .getRandomRecipe()
       .subscribe({
         next: (recipe: Recipe) => {
-          this.isLoading = false;
-          clearInterval(timer);
           this.recipeService.setRecipe(recipe);
           console.log(recipe);
           this.router.navigate([`/recipe/${recipe.id}`]);
         },
         error: (error: Error) => {
           // Show a snackbar explaining that an error occurred
+          this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
           this.isLoading = false;
           clearInterval(timer);
-          this.snackBar.open(error.message, 'Dismiss');
         },
       });
   }

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -61,8 +61,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       .getRandomRecipe()
       .subscribe({
         next: (recipe: Recipe) => {
-          this.recipeService.setRecipe(recipe);
-          console.log(recipe);
           this.router.navigate([`/recipe/${recipe.id}`]);
         },
         error: (error: Error) => {

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar color="primary" class="toolbar">
-  @if (isSmallScreen) {
+  @if (isSmallScreen()) {
   <!-- Show a hamburger menu on small screens -->
   <!-- All material icons are found at: https://fonts.google.com/icons -->
   <button
@@ -29,16 +29,16 @@
   }
   <span class="spacer"></span>
   <!-- Update the material icon to match the corresponding boolean value -->
-  @if (isRecipePage) {
+  @if (isRecipePage()) {
   <button
     mat-icon-button
     class="favorite-icon"
     [attr.aria-label]="
-      (isFavorite ? 'Unfavorite' : 'Favorite') + ' this recipe'
+      (isFavorite() ? 'Unfavorite' : 'Favorite') + ' this recipe'
     "
     (click)="toggleFavoriteRecipe()"
   >
-    <mat-icon [fontIcon]="isFavorite ? 'favorite' : 'favorite_border'" />
+    <mat-icon [fontIcon]="isFavorite() ? 'favorite' : 'favorite_border'" />
   </button>
   <button
     mat-icon-button
@@ -58,7 +58,7 @@
   <mat-sidenav
     #snav
     class="sidenav"
-    [mode]="isSmallScreen ? 'over' : 'side'"
+    [mode]="isSmallScreen() ? 'over' : 'side'"
     [fixedInViewport]="true"
     fixedTopGap="56"
   >

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -37,6 +37,7 @@
       (isFavorite() ? 'Unfavorite' : 'Favorite') + ' this recipe'
     "
     (click)="toggleFavoriteRecipe()"
+    [disabled]="chef() === undefined"
   >
     <mat-icon [fontIcon]="isFavorite() ? 'favorite' : 'favorite_border'" />
   </button>

--- a/src/app/components/navbar/navbar.component.spec.ts
+++ b/src/app/components/navbar/navbar.component.spec.ts
@@ -41,14 +41,14 @@ describe('NavbarComponent', () => {
     const shareIcon =
       rootElement.querySelector<HTMLButtonElement>('.share-icon');
 
-    expect(navbarComponent.isRecipePage).toBeFalse();
+    expect(navbarComponent.isRecipePage()).toBeFalse();
     expect(favoriteIcon).toBeNull();
     expect(shareIcon).toBeNull();
   });
 
   it('should display the hamburger menu on small screens', () => {
     // Check that the navbar contains the app name and a hamburger icon
-    navbarComponent.isSmallScreen = true;
+    navbarComponent.isSmallScreen.set(true);
     fixture.detectChanges();
 
     const menuIcon = rootElement.querySelector<HTMLButtonElement>('.menu-icon');
@@ -64,14 +64,14 @@ describe('NavbarComponent', () => {
     const shareIcon =
       rootElement.querySelector<HTMLButtonElement>('.share-icon');
 
-    expect(navbarComponent.isRecipePage).toBeFalse();
+    expect(navbarComponent.isRecipePage()).toBeFalse();
     expect(favoriteIcon).toBeNull();
     expect(shareIcon).toBeNull();
   });
 
   it('should toggle the sidenav when clicking the hamburger icon', () => {
     // Check that the sidenav appears and disappears when clicking the hamburger icon
-    navbarComponent.isSmallScreen = true;
+    navbarComponent.isSmallScreen.set(true);
     fixture.detectChanges();
 
     const sidenav = rootElement.querySelector<HTMLDivElement>('.sidenav');
@@ -94,16 +94,16 @@ describe('NavbarComponent', () => {
 
   it('should toggle isFavorite', () => {
     // Check that the toggleFavoriteRecipe method toggles the isFavorite property
-    const oldIsFavorite = navbarComponent.isFavorite;
+    const oldIsFavorite = navbarComponent.isFavorite();
     navbarComponent.toggleFavoriteRecipe();
 
-    const newIsFavorite = navbarComponent.isFavorite;
+    const newIsFavorite = navbarComponent.isFavorite();
     expect(newIsFavorite).not.toBe(oldIsFavorite);
   });
 
   it('should show the correct heart icon', () => {
     // Check that the heart icon is filled when favoriting and isn't filled when unfavoriting
-    navbarComponent.isRecipePage = true;
+    navbarComponent.isRecipePage.set(true);
     fixture.detectChanges();
 
     const favoriteButton =
@@ -128,7 +128,7 @@ describe('NavbarComponent', () => {
   it('should call shareRecipe after clicking the share button', () => {
     // Check that shareRecipe is called after clicking the share button
     spyOn(navbarComponent, 'shareRecipe');
-    navbarComponent.isRecipePage = true;
+    navbarComponent.isRecipePage.set(true);
     fixture.detectChanges();
 
     const shareIcon =

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,5 +1,12 @@
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { Component, OnDestroy, OnInit, Type, inject } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  Type,
+  inject,
+  signal,
+} from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
@@ -32,27 +39,23 @@ export class NavbarComponent implements OnInit, OnDestroy {
   private titleService = inject(Title);
   private snackBar = inject(MatSnackBar);
 
-  isSmallScreen: boolean;
+  // Detect breakpoint changes so the template can respond
+  isSmallScreen = signal(this.breakpointObserver.isMatched(Breakpoints.XSmall));
   // Navigation links to show in the sidenav
-  navItems = environment.production
+  readonly navItems = environment.production
     ? [routes.home, routes.search, routes.glossary]
     : [routes.home, routes.search, routes.glossary, routes.profile];
 
-  isRecipePage = false;
-  isFavorite = false;
+  isRecipePage = signal(false);
+  isFavorite = signal(false);
   breakpointSubscription?: Subscription;
-
-  constructor() {
-    // Detect breakpoint changes so the template can respond
-    this.isSmallScreen = this.breakpointObserver.isMatched(Breakpoints.XSmall);
-  }
 
   ngOnInit(): void {
     this.breakpointSubscription = this.breakpointObserver
       .observe(Breakpoints.XSmall)
       .subscribe(() => {
-        this.isSmallScreen = this.breakpointObserver.isMatched(
-          Breakpoints.XSmall
+        this.isSmallScreen.set(
+          this.breakpointObserver.isMatched(Breakpoints.XSmall)
         );
       });
   }
@@ -63,12 +66,12 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   onRouterOutletActivate(event: Type<Component>) {
     // Check if the recipe component is shown in the router outlet
-    this.isRecipePage = event instanceof RecipeComponent;
+    this.isRecipePage.set(event instanceof RecipeComponent);
   }
 
   toggleFavoriteRecipe() {
     // Placeholder for the heart button
-    this.isFavorite = !this.isFavorite;
+    this.isFavorite.update((isFavorite) => !isFavorite);
   }
 
   async shareRecipe() {

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,12 +1,6 @@
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import {
-  Component,
-  OnDestroy,
-  OnInit,
-  Type,
-  inject,
-  signal,
-} from '@angular/core';
+import { Component, Type, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
@@ -15,7 +9,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { Title } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { Subscription } from 'rxjs';
 
 import { RecipeComponent } from '../recipe/recipe.component';
 import { routes } from 'src/app/app-routing.module';
@@ -34,7 +27,7 @@ import { environment } from 'src/environments/environment';
   templateUrl: './navbar.component.html',
   styleUrl: './navbar.component.scss',
 })
-export class NavbarComponent implements OnInit, OnDestroy {
+export class NavbarComponent {
   private breakpointObserver = inject(BreakpointObserver);
   private titleService = inject(Title);
   private snackBar = inject(MatSnackBar);
@@ -48,20 +41,16 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   isRecipePage = signal(false);
   isFavorite = signal(false);
-  breakpointSubscription?: Subscription;
 
-  ngOnInit(): void {
-    this.breakpointSubscription = this.breakpointObserver
+  constructor() {
+    this.breakpointObserver
       .observe(Breakpoints.XSmall)
+      .pipe(takeUntilDestroyed())
       .subscribe(() => {
         this.isSmallScreen.set(
           this.breakpointObserver.isMatched(Breakpoints.XSmall)
         );
       });
-  }
-
-  ngOnDestroy(): void {
-    this.breakpointSubscription?.unsubscribe();
   }
 
   onRouterOutletActivate(event: Type<Component>) {

--- a/src/app/components/profile/delete-account/delete-account.component.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.ts
@@ -1,11 +1,12 @@
 import {
   Component,
+  DestroyRef,
   inject,
-  OnDestroy,
   OnInit,
   Signal,
   signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   ReactiveFormsModule,
   FormGroup,
@@ -19,7 +20,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { finalize } from 'rxjs';
 
 import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
@@ -59,12 +60,11 @@ const usernamesMatchValidator =
   templateUrl: './delete-account.component.html',
   styleUrl: './delete-account.component.scss',
 })
-export class DeleteAccountComponent implements OnInit, OnDestroy {
+export class DeleteAccountComponent implements OnInit {
   private chefService = inject(ChefService);
   private snackBar = inject(MatSnackBar);
   private router = inject(Router);
-
-  private chefServiceSubscription?: Subscription;
+  private destroyRef = inject(DestroyRef);
 
   isLoading = signal(false);
   private chefUsername = signal<string | null>(null);
@@ -85,10 +85,6 @@ export class DeleteAccountComponent implements OnInit, OnDestroy {
     }
   }
 
-  ngOnDestroy(): void {
-    this.chefServiceSubscription?.unsubscribe();
-  }
-
   deleteAccount() {
     this.isLoading.set(true);
     const token = localStorage.getItem(Constants.LocalStorage.token);
@@ -98,8 +94,14 @@ export class DeleteAccountComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.chefServiceSubscription = this.chefService
+    this.chefService
       .deleteChef(token)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.isLoading.set(false);
+        })
+      )
       .subscribe({
         next: () => {
           localStorage.removeItem(Constants.LocalStorage.token);
@@ -108,9 +110,6 @@ export class DeleteAccountComponent implements OnInit, OnDestroy {
         },
         error: (error) => {
           this.snackBar.open(error.message, 'Dismiss');
-        },
-        complete: () => {
-          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/delete-account/delete-account.component.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.ts
@@ -102,15 +102,15 @@ export class DeleteAccountComponent implements OnInit, OnDestroy {
       .deleteChef(token)
       .subscribe({
         next: () => {
-          this.isLoading.set(false);
-
           localStorage.removeItem(Constants.LocalStorage.token);
           this.snackBar.open('Your account has been deleted.', 'Dismiss');
           this.router.navigate([routes.profile.path]);
         },
         error: (error) => {
-          this.isLoading.set(false);
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/forgot-password/forgot-password.component.ts
+++ b/src/app/components/profile/forgot-password/forgot-password.component.ts
@@ -77,12 +77,13 @@ export class ForgotPasswordComponent implements OnDestroy {
       .updateChef(chefUpdate)
       .subscribe({
         next: () => {
-          this.isLoading.set(false);
           this.emailSent.set(true);
         },
         error: (error) => {
-          this.isLoading.set(false);
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/forgot-password/forgot-password.component.ts
+++ b/src/app/components/profile/forgot-password/forgot-password.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnDestroy, signal } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   ReactiveFormsModule,
   FormGroup,
@@ -12,7 +13,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { RouterModule } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { finalize } from 'rxjs';
 
 import { profileRoutes } from 'src/app/app-routing.module';
 import { ChefUpdate, ChefUpdateType } from 'src/app/models/profile.model';
@@ -32,12 +33,11 @@ import { ChefService } from 'src/app/services/chef.service';
   templateUrl: './forgot-password.component.html',
   styleUrl: './forgot-password.component.scss',
 })
-export class ForgotPasswordComponent implements OnDestroy {
+export class ForgotPasswordComponent {
   private chefService = inject(ChefService);
   private snackBar = inject(MatSnackBar);
+  private destroyRef = inject(DestroyRef);
   profileRoutes = profileRoutes;
-
-  private chefServiceSubscription?: Subscription;
 
   isLoading = signal(false);
   emailSent = signal(false);
@@ -61,10 +61,6 @@ export class ForgotPasswordComponent implements OnDestroy {
     [this.formErrors.emailInvalid]: 'Error: Invalid email',
   } as const;
 
-  ngOnDestroy(): void {
-    this.chefServiceSubscription?.unsubscribe();
-  }
-
   resetPassword() {
     this.isLoading.set(true);
     const { email } = this.formGroup.value;
@@ -73,17 +69,20 @@ export class ForgotPasswordComponent implements OnDestroy {
       email: email ?? '',
     };
 
-    this.chefServiceSubscription = this.chefService
+    this.chefService
       .updateChef(chefUpdate)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.isLoading.set(false);
+        })
+      )
       .subscribe({
         next: () => {
           this.emailSent.set(true);
         },
         error: (error) => {
           this.snackBar.open(error.message, 'Dismiss');
-        },
-        complete: () => {
-          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/login/login.component.html
+++ b/src/app/components/profile/login/login.component.html
@@ -44,9 +44,9 @@
         (click)="togglePasswordVisibility($event)"
         [attr.aria-label]="showPassword() ? 'Hide password' : 'Show password'"
       >
-        <mat-icon>{{
-          showPassword() ? "visibility_off" : "visibility"
-        }}</mat-icon>
+        <mat-icon
+          [fontIcon]="showPassword() ? 'visibility_off' : 'visibility'"
+        />
       </button>
       @if (formGroup.controls.password.invalid) {
       <mat-error>{{ errors.required(formControls.password) }}</mat-error>

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -78,7 +78,6 @@ export class LoginComponent implements OnDestroy {
       .login(loginCredentials)
       .subscribe({
         next: ({ token, emailVerified }) => {
-          this.isLoading.set(false);
           localStorage.setItem(Constants.LocalStorage.token, token);
 
           // Check if the user signed up, but didn't verify their email yet
@@ -103,8 +102,10 @@ export class LoginComponent implements OnDestroy {
           }
         },
         error: (error) => {
-          this.isLoading.set(false);
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnDestroy, signal } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   FormControl,
   FormGroup,
@@ -12,7 +13,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { finalize } from 'rxjs';
 
 import { ChefService } from 'src/app/services/chef.service';
 import { LoginCredentials } from 'src/app/models/profile.model';
@@ -33,14 +34,13 @@ import Constants from 'src/app/constants/constants';
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })
-export class LoginComponent implements OnDestroy {
+export class LoginComponent {
   private chefService = inject(ChefService);
   private snackBar = inject(MatSnackBar);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
   profileRoutes = profileRoutes;
-
-  private chefServiceSubscription?: Subscription;
 
   showPassword = signal(false);
   isLoading = signal(false);
@@ -57,10 +57,6 @@ export class LoginComponent implements OnDestroy {
     required: (field: string) => `Error: ${field} is required`,
   } as const;
 
-  ngOnDestroy(): void {
-    this.chefServiceSubscription?.unsubscribe();
-  }
-
   togglePasswordVisibility(event: MouseEvent) {
     event.preventDefault(); // don't submit the form
     this.showPassword.set(!this.showPassword());
@@ -74,8 +70,14 @@ export class LoginComponent implements OnDestroy {
       password: password ?? '',
     };
 
-    this.chefServiceSubscription = this.chefService
+    this.chefService
       .login(loginCredentials)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.isLoading.set(false);
+        })
+      )
       .subscribe({
         next: ({ token, emailVerified }) => {
           localStorage.setItem(Constants.LocalStorage.token, token);
@@ -103,9 +105,6 @@ export class LoginComponent implements OnDestroy {
         },
         error: (error) => {
           this.snackBar.open(error.message, 'Dismiss');
-        },
-        complete: () => {
-          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/sign-up/sign-up.component.html
+++ b/src/app/components/profile/sign-up/sign-up.component.html
@@ -46,9 +46,9 @@
         (click)="togglePasswordVisibility($event)"
         [attr.aria-label]="showPassword() ? 'Hide password' : 'Show password'"
       >
-        <mat-icon>{{
-          showPassword() ? "visibility_off" : "visibility"
-        }}</mat-icon>
+        <mat-icon
+          [fontIcon]="showPassword() ? 'visibility_off' : 'visibility'"
+        />
       </button>
       @if (formGroup.controls.password.hasError(formErrors.required)) {
       <mat-error>{{ errors.required(formControls.password) }}</mat-error>
@@ -75,9 +75,9 @@
           showPasswordConfirm() ? 'Hide password' : 'Show password'
         "
       >
-        <mat-icon>{{
-          showPasswordConfirm() ? "visibility_off" : "visibility"
-        }}</mat-icon>
+        <mat-icon
+          [fontIcon]="showPasswordConfirm() ? 'visibility_off' : 'visibility'"
+        />
       </button>
       @if (formGroup.hasError(formErrors.passwordMismatch)) {
       <mat-error>{{ errors.passwordMismatch }}</mat-error>

--- a/src/app/components/profile/sign-up/sign-up.component.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.ts
@@ -128,7 +128,6 @@ export class SignUpComponent implements OnDestroy {
       .createChef(loginCredentials)
       .subscribe({
         next: ({ token, emailVerified }) => {
-          this.isLoading.set(false);
           localStorage.setItem(Constants.LocalStorage.token, token);
 
           if (!emailVerified) {
@@ -149,8 +148,10 @@ export class SignUpComponent implements OnDestroy {
           }
         },
         error: (error) => {
-          this.isLoading.set(false);
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/update-email/update-email.component.ts
+++ b/src/app/components/profile/update-email/update-email.component.ts
@@ -77,7 +77,6 @@ export class UpdateEmailComponent implements OnDestroy {
       .updateChef(fields, token)
       .subscribe({
         next: ({ token }) => {
-          this.isLoading.set(false);
           this.emailSent.set(true);
 
           if (token !== undefined) {
@@ -85,8 +84,10 @@ export class UpdateEmailComponent implements OnDestroy {
           }
         },
         error: (error) => {
-          this.isLoading.set(false);
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/profile/update-password/update-password.component.html
+++ b/src/app/components/profile/update-password/update-password.component.html
@@ -21,9 +21,9 @@
         (click)="togglePasswordVisibility($event)"
         [attr.aria-label]="showPassword() ? 'Hide password' : 'Show password'"
       >
-        <mat-icon>{{
-          showPassword() ? "visibility_off" : "visibility"
-        }}</mat-icon>
+        <mat-icon
+          [fontIcon]="showPassword() ? 'visibility_off' : 'visibility'"
+        />
       </button>
       @if (formGroup.controls.password.hasError(formErrors.required)) {
       <mat-error>{{ errors.required }}</mat-error>
@@ -50,9 +50,9 @@
           showPasswordConfirm() ? 'Hide password' : 'Show password'
         "
       >
-        <mat-icon>{{
-          showPasswordConfirm() ? "visibility_off" : "visibility"
-        }}</mat-icon>
+        <mat-icon
+          [fontIcon]="showPasswordConfirm() ? 'visibility_off' : 'visibility'"
+        />
       </button>
       @if (formGroup.hasError(formErrors.passwordMismatch)) {
       <mat-error>{{ errors.passwordMismatch }}</mat-error>

--- a/src/app/components/profile/update-password/update-password.component.ts
+++ b/src/app/components/profile/update-password/update-password.component.ts
@@ -131,8 +131,6 @@ export class UpdatePasswordComponent implements OnInit, OnDestroy {
       .updateChef(fields, token)
       .subscribe({
         next: () => {
-          this.isLoading.set(false);
-
           // The token will be revoked, so sign out the user
           localStorage.removeItem(Constants.LocalStorage.token);
           this.snackBar.open(
@@ -142,8 +140,10 @@ export class UpdatePasswordComponent implements OnInit, OnDestroy {
           this.router.navigate([profileRoutes.login.path]);
         },
         error: (error) => {
-          this.isLoading.set(false);
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading.set(false);
         },
       });
   }

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -26,7 +26,7 @@
       </button>
     </span>
     <app-recipe-rating
-      [averageRating]="recipe().averageRating"
+      [averageRating]="recipe().averageRating ?? null"
       [totalRatings]="recipe().totalRatings ?? 0"
       [myRating]=""
       (handleRate)="onRate($event)"

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -22,7 +22,7 @@
       >
         <mat-icon
           [fontIcon]="isFavorite() ? 'favorite' : 'favorite_border'"
-          color="warn"
+          [color]="chef() !== undefined ? 'warn' : null"
         />
       </button>
     </span>

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -18,6 +18,7 @@
           (isFavorite() ? 'Unfavorite' : 'Favorite') + ' this recipe'
         "
         (click)="toggleFavoriteRecipe($event)"
+        [disabled]="chef() === undefined"
       >
         <mat-icon
           [fontIcon]="isFavorite() ? 'favorite' : 'favorite_border'"

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -25,6 +25,12 @@
         />
       </button>
     </span>
+    <app-recipe-rating
+      [averageRating]="recipe().averageRating"
+      [totalRatings]="recipe().totalRatings ?? 0"
+      [myRating]=""
+      (handleRate)="onRate($event)"
+    />
     <span class="recipe-info-row">
       <p [ngPlural]="recipe().time">
         <!-- Pluralize the recipe time (if a recipe only takes a minute) -->

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -29,7 +29,7 @@
     <app-recipe-rating
       [averageRating]="recipe().averageRating ?? null"
       [totalRatings]="recipe().totalRatings ?? 0"
-      [myRating]="chef()?.ratings?.[recipe().id]"
+      [myRating]="chef()?.ratings?.[recipe().id] ?? undefined"
       [enabled]="chef() !== undefined"
       (handleRate)="onRate($event)"
     />

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -15,12 +15,12 @@
         mat-icon-button
         class="recipe-favorite-icon"
         [attr.aria-label]="
-          (isFavorite ? 'Unfavorite' : 'Favorite') + ' this recipe'
+          (isFavorite() ? 'Unfavorite' : 'Favorite') + ' this recipe'
         "
         (click)="toggleFavoriteRecipe($event)"
       >
         <mat-icon
-          [fontIcon]="isFavorite ? 'favorite' : 'favorite_border'"
+          [fontIcon]="isFavorite() ? 'favorite' : 'favorite_border'"
           color="warn"
         />
       </button>
@@ -43,8 +43,8 @@
         </ng-template>
       </p>
 
-      @if (calories !== undefined) {
-      <p>{{ calories.amount | number : "1.0-0" }} {{ calories.unit }}</p>
+      @if (calories() !== undefined) {
+      <p>{{ calories()?.amount | number : "1.0-0" }} {{ calories()?.unit }}</p>
       }
     </span>
   </mat-card-content>

--- a/src/app/components/recipe-card/recipe-card.component.html
+++ b/src/app/components/recipe-card/recipe-card.component.html
@@ -28,7 +28,8 @@
     <app-recipe-rating
       [averageRating]="recipe().averageRating ?? null"
       [totalRatings]="recipe().totalRatings ?? 0"
-      [myRating]=""
+      [myRating]="chef()?.ratings?.[recipe().id]"
+      [enabled]="chef() !== undefined"
       (handleRate)="onRate($event)"
     />
     <span class="recipe-info-row">

--- a/src/app/components/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/recipe-card/recipe-card.component.spec.ts
@@ -48,7 +48,7 @@ describe('RecipeCardComponent', () => {
   it('should create a recipe card', () => {
     // All elements should be visible on the recipe card
     expect(recipeCardComponent).toBeTruthy();
-    expect(recipeCardComponent.calories).toEqual(
+    expect(recipeCardComponent.calories()).toEqual(
       mockRecipe.nutrients.find((nutrient) => nutrient.name === 'Calories')
     );
 
@@ -66,26 +66,26 @@ describe('RecipeCardComponent', () => {
       `Time: ${mockRecipe.time} minutes`
     );
     expect(recipeContent?.textContent).toContain(
-      `${Math.round(recipeCardComponent.calories!.amount)} ${
-        recipeCardComponent.calories?.unit
+      `${Math.round(recipeCardComponent.calories()!.amount)} ${
+        recipeCardComponent.calories()?.unit
       }`
     );
   });
 
   it('should toggle isFavorite', () => {
     // Check that isFavorite toggles when the heart button is clicked
-    expect(recipeCardComponent.isFavorite).toBeFalse();
+    expect(recipeCardComponent.isFavorite()).toBeFalse();
 
     const favoriteButton = rootElement.querySelector<HTMLButtonElement>(
       '.recipe-favorite-icon'
     );
     favoriteButton?.click();
     fixture.detectChanges();
-    expect(recipeCardComponent.isFavorite).toBeTrue();
+    expect(recipeCardComponent.isFavorite()).toBeTrue();
 
     favoriteButton?.click();
     fixture.detectChanges();
-    expect(recipeCardComponent.isFavorite).toBeFalse();
+    expect(recipeCardComponent.isFavorite()).toBeFalse();
   });
 
   it('should open the selected recipe', () => {

--- a/src/app/components/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/recipe-card/recipe-card.component.spec.ts
@@ -8,27 +8,20 @@ import { Router, RouterModule } from '@angular/router';
 
 import { RecipeCardComponent } from './recipe-card.component';
 import { mockRecipe } from 'src/app/models/recipe.mock';
-import { RecipeService } from 'src/app/services/recipe.service';
 
 describe('RecipeCardComponent', () => {
   let recipeCardComponent: RecipeCardComponent;
   let fixture: ComponentFixture<RecipeCardComponent>;
   let rootElement: HTMLElement;
 
-  let mockRecipeService: jasmine.SpyObj<RecipeService>;
   let mockRouter: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
-    mockRecipeService = jasmine.createSpyObj('RecipeService', ['setRecipe']);
     mockRouter = jasmine.createSpyObj('Router', ['navigate']);
 
     await TestBed.configureTestingModule({
       imports: [RecipeCardComponent, RouterModule.forRoot([])],
       providers: [
-        {
-          provide: RecipeService,
-          useValue: mockRecipeService,
-        },
         {
           provide: Router,
           useValue: mockRouter,
@@ -92,7 +85,6 @@ describe('RecipeCardComponent', () => {
     // Check that the correct recipe is set and navigated to
     const recipeCard = rootElement.querySelector<HTMLElement>('.recipe-card');
     recipeCard?.click();
-    expect(mockRecipeService.setRecipe).toHaveBeenCalledWith(mockRecipe);
     expect(mockRouter.navigate).toHaveBeenCalledWith([
       `/recipe/${mockRecipe.id}`,
     ]);

--- a/src/app/components/recipe-card/recipe-card.component.ts
+++ b/src/app/components/recipe-card/recipe-card.component.ts
@@ -84,8 +84,7 @@ export class RecipeCardComponent {
 
   openRecipe() {
     const recipe = this.recipe();
-    this.recipeService.setRecipe(recipe);
-    console.log(recipe);
+    this.recipeService.recipe.set(recipe);
     this.router.navigate([`/recipe/${recipe.id}`]);
     // Scroll to the top so the recipe header can be viewed
     const sidenav = document.querySelector<HTMLElement>('.sidenav-content');

--- a/src/app/components/recipe-card/recipe-card.component.ts
+++ b/src/app/components/recipe-card/recipe-card.component.ts
@@ -7,10 +7,17 @@ import { Router } from '@angular/router';
 
 import Recipe from 'src/app/models/recipe.model';
 import { RecipeService } from 'src/app/services/recipe.service';
+import { RecipeRatingComponent } from '../recipe-rating/recipe-rating.component';
 
 @Component({
   selector: 'app-recipe-card',
-  imports: [CommonModule, MatButtonModule, MatCardModule, MatIconModule],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    RecipeRatingComponent,
+  ],
   templateUrl: './recipe-card.component.html',
   styleUrl: './recipe-card.component.scss',
 })
@@ -33,6 +40,10 @@ export class RecipeCardComponent implements OnInit {
     event.stopPropagation();
     // Placeholder for the heart button
     this.isFavorite = !this.isFavorite;
+  }
+
+  onRate(rating: number) {
+    console.log('clicked rating:', rating);
   }
 
   openRecipe() {

--- a/src/app/components/recipe-card/recipe-card.component.ts
+++ b/src/app/components/recipe-card/recipe-card.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, inject, input } from '@angular/core';
+import { Component, computed, inject, input, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -24,28 +24,24 @@ import Constants from 'src/app/constants/constants';
   templateUrl: './recipe-card.component.html',
   styleUrl: './recipe-card.component.scss',
 })
-export class RecipeCardComponent implements OnInit {
+export class RecipeCardComponent {
   private recipeService = inject(RecipeService);
   private chefService = inject(ChefService);
   private router = inject(Router);
   private snackBar = inject(MatSnackBar);
 
   readonly recipe = input.required<Recipe>();
-  calories?: Recipe['nutrients'][number];
-  isFavorite = false;
+  readonly calories = computed(() =>
+    this.recipe().nutrients.find((nutrient) => nutrient.name === 'Calories')
+  );
+  isFavorite = signal(false);
   chef = this.chefService.chef;
-
-  ngOnInit(): void {
-    this.calories = this.recipe().nutrients.find(
-      (nutrient) => nutrient.name === 'Calories'
-    );
-  }
 
   toggleFavoriteRecipe(event: MouseEvent) {
     // Don't trigger the card's click event
     event.stopPropagation();
     // Placeholder for the heart button
-    this.isFavorite = !this.isFavorite;
+    this.isFavorite.update((isFavorite) => !isFavorite);
   }
 
   onRate(rating: number) {

--- a/src/app/components/recipe-card/recipe-card.component.ts
+++ b/src/app/components/recipe-card/recipe-card.component.ts
@@ -108,6 +108,15 @@ export class RecipeCardComponent {
             }
         );
 
+        this.recipeService
+          .toggleFavoriteRecentRecipe(recipeId)
+          .catch((error) => {
+            console.error(
+              'Failed to toggle isFavorite for recent recipe:',
+              error.message
+            );
+          });
+
         if (token !== undefined) {
           localStorage.setItem(Constants.LocalStorage.token, token);
         }

--- a/src/app/components/recipe-rating/recipe-rating.component.html
+++ b/src/app/components/recipe-rating/recipe-rating.component.html
@@ -19,7 +19,7 @@
   </button>
   }
   <p class="rating-text">
-    @if (averageRating() !== undefined) {
+    @if (averageRating() !== null) {
     <!-- Round rating to 1 decimal place -->
     ({{ averageRating() | number : "1.0-1" }}/5,
     {{ totalRatings() | shorthand }}

--- a/src/app/components/recipe-rating/recipe-rating.component.html
+++ b/src/app/components/recipe-rating/recipe-rating.component.html
@@ -1,0 +1,31 @@
+<div class="recipe-rating" [attr.aria-label]="ratingLabel()">
+  @for (i of RATINGS; track i) {
+  <button
+    matButton
+    class="rating-button"
+    (click)="handleRate.emit(i)"
+    (mouseenter)="onHoverStart(i)"
+    (mouseleave)="onHoverEnd()"
+    [disabled]="!enabled"
+    [attr.aria-label]="starRatingInputLabel(i)"
+    [style]="{
+      color:
+        hoveringStar() !== undefined || myRating() !== undefined
+          ? '#E65100'
+          : '#FFA000'
+    }"
+  >
+    <mat-icon [fontIcon]="starIcon(i)" />
+  </button>
+  }
+  <p class="rating-text">
+    @if (averageRating() !== undefined) {
+    <!-- Round rating to 1 decimal place -->
+    ({{ averageRating() | number : "1.0-1" }}/5,
+    {{ totalRatings() | shorthand }}
+    {{ totalRatings() === 1 ? "rating" : "ratings" }}) } @else { ({{
+      totalRatings() | shorthand
+    }}
+    ratings) }
+  </p>
+</div>

--- a/src/app/components/recipe-rating/recipe-rating.component.html
+++ b/src/app/components/recipe-rating/recipe-rating.component.html
@@ -6,13 +6,14 @@
     (click)="onClick($event, i)"
     (mouseenter)="onHoverStart(i)"
     (mouseleave)="onHoverEnd()"
-    [disabled]="!enabled"
+    [disabled]="!enabled()"
     [attr.aria-label]="starRatingInputLabel(i)"
     [style]="{
-      color:
-        hoveringStar() !== undefined || myRating() !== undefined
-          ? ORANGE_900
-          : AMBER_700
+      color: !enabled()
+        ? null
+        : hoveringStar() !== undefined || myRating() !== undefined
+        ? ORANGE_900
+        : AMBER_700
     }"
   >
     <mat-icon [fontIcon]="starIcon(i)" />

--- a/src/app/components/recipe-rating/recipe-rating.component.html
+++ b/src/app/components/recipe-rating/recipe-rating.component.html
@@ -3,7 +3,7 @@
   <button
     matButton
     class="rating-button"
-    (click)="handleRate.emit(i)"
+    (click)="onClick($event, i)"
     (mouseenter)="onHoverStart(i)"
     (mouseleave)="onHoverEnd()"
     [disabled]="!enabled"

--- a/src/app/components/recipe-rating/recipe-rating.component.html
+++ b/src/app/components/recipe-rating/recipe-rating.component.html
@@ -11,8 +11,8 @@
     [style]="{
       color:
         hoveringStar() !== undefined || myRating() !== undefined
-          ? '#E65100'
-          : '#FFA000'
+          ? ORANGE_900
+          : AMBER_700
     }"
   >
     <mat-icon [fontIcon]="starIcon(i)" />

--- a/src/app/components/recipe-rating/recipe-rating.component.scss
+++ b/src/app/components/recipe-rating/recipe-rating.component.scss
@@ -1,0 +1,11 @@
+.recipe-rating {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-left: 8px;
+  margin-right: 8px;
+
+  .rating-text {
+    margin-bottom: 0;
+  }
+}

--- a/src/app/components/recipe-rating/recipe-rating.component.spec.ts
+++ b/src/app/components/recipe-rating/recipe-rating.component.spec.ts
@@ -14,7 +14,7 @@ describe('RecipeRatingComponent', () => {
     myRating,
     hoveringStar,
   }: {
-    averageRating?: number;
+    averageRating: number | null;
     totalRatings: number;
     myRating?: number;
     hoveringStar?: number;
@@ -119,7 +119,7 @@ describe('RecipeRatingComponent', () => {
   it('should omit the average rating if not available', () => {
     // Given no ratings
     initializeRecipeRating({
-      averageRating: undefined,
+      averageRating: null,
       totalRatings: 0,
     });
 

--- a/src/app/components/recipe-rating/recipe-rating.component.spec.ts
+++ b/src/app/components/recipe-rating/recipe-rating.component.spec.ts
@@ -1,0 +1,173 @@
+import { ComponentRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecipeRatingComponent } from './recipe-rating.component';
+
+describe('RecipeRatingComponent', () => {
+  let recipeRatingComponent: RecipeRatingComponent;
+  let recipeRatingRef: ComponentRef<RecipeRatingComponent>;
+  let fixture: ComponentFixture<RecipeRatingComponent>;
+
+  const initializeRecipeRating = ({
+    averageRating,
+    totalRatings,
+    myRating,
+    hoveringStar,
+  }: {
+    averageRating?: number;
+    totalRatings: number;
+    myRating?: number;
+    hoveringStar?: number;
+  }) => {
+    recipeRatingRef.setInput('averageRating', averageRating);
+    recipeRatingRef.setInput('totalRatings', totalRatings);
+    recipeRatingRef.setInput('myRating', myRating);
+    recipeRatingComponent.hoveringStar.set(hoveringStar);
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RecipeRatingComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecipeRatingComponent);
+    recipeRatingComponent = fixture.componentInstance;
+    recipeRatingRef = fixture.componentRef;
+    // Don't call detectChanges() until all required inputs are set
+  });
+
+  it('should create', () => {
+    expect(recipeRatingComponent).toBeTruthy();
+    expect(recipeRatingComponent.starRatingInputLabel(1)).toBe('Rate 1 star');
+    expect(recipeRatingComponent.starRatingInputLabel(5)).toBe('Rate 5 stars');
+  });
+
+  it('should show a full star rating', () => {
+    // Given an average rating of 4
+    initializeRecipeRating({
+      averageRating: 4,
+      totalRatings: 1,
+    });
+
+    // Then the first 4 stars should be filled
+    [1, 2, 3, 4].forEach((i) => {
+      expect(recipeRatingComponent.starIcon(i)).toBe('star');
+    });
+    expect(recipeRatingComponent.starIcon(5)).toBe('star_outlined');
+
+    expect(recipeRatingComponent.ratingLabel()).toBe(
+      'Average rating: 4 out of 5 stars'
+    );
+  });
+
+  it('should show a half-star rating', () => {
+    // Given an average rating of 2.5
+    initializeRecipeRating({
+      averageRating: 2.5,
+      totalRatings: 4,
+    });
+
+    // Then half a star should be filled
+    expect(recipeRatingComponent.starIcon(1)).toBe('star');
+    expect(recipeRatingComponent.starIcon(2)).toBe('star');
+    expect(recipeRatingComponent.starIcon(3)).toBe('star_half');
+    expect(recipeRatingComponent.starIcon(4)).toBe('star_outlined');
+    expect(recipeRatingComponent.starIcon(5)).toBe('star_outlined');
+
+    expect(recipeRatingComponent.ratingLabel()).toBe(
+      'Average rating: 2.5 out of 5 stars'
+    );
+  });
+
+  it('should round down a decimal rating', () => {
+    // Given an average rating of 26/6 (4.333)
+    initializeRecipeRating({
+      averageRating: 26 / 6,
+      totalRatings: 6,
+    });
+
+    // Then the rating should be rounded down
+    [1, 2, 3, 4].forEach((i) => {
+      expect(recipeRatingComponent.starIcon(i)).toBe('star');
+    });
+    expect(recipeRatingComponent.starIcon(5)).toBe('star_outlined');
+
+    expect(recipeRatingComponent.ratingLabel()).toBe(
+      'Average rating: 4.333333333333333 out of 5 stars'
+    );
+  });
+
+  it('should round up a decimal rating', () => {
+    // Given an average rating of 28/6 (4.667)
+    initializeRecipeRating({
+      averageRating: 28 / 6,
+      totalRatings: 6,
+    });
+
+    // Then the rating should be rounded up
+    [1, 2, 3, 4].forEach((i) => {
+      expect(recipeRatingComponent.starIcon(i)).toBe('star');
+    });
+    expect(recipeRatingComponent.starIcon(5)).toBe('star_half');
+
+    expect(recipeRatingComponent.ratingLabel()).toBe(
+      'Average rating: 4.666666666666667 out of 5 stars'
+    );
+  });
+
+  it('should omit the average rating if not available', () => {
+    // Given no ratings
+    initializeRecipeRating({
+      averageRating: undefined,
+      totalRatings: 0,
+    });
+
+    // Then no stars should be filled
+    [1, 2, 3, 4].forEach((i) => {
+      expect(recipeRatingComponent.starIcon(i)).toBe('star_outlined');
+    });
+
+    expect(recipeRatingComponent.ratingLabel()).toBe('No ratings available');
+  });
+
+  it('should display my rating if available', () => {
+    // Given a chef's rating
+    initializeRecipeRating({
+      averageRating: 3,
+      totalRatings: 2,
+      myRating: 1,
+    });
+
+    // Then that should be shown instead of the average rating
+    expect(recipeRatingComponent.starIcon(1)).toBe('star');
+    [2, 3, 4, 5].forEach((i) => {
+      expect(recipeRatingComponent.starIcon(i)).toBe('star_outlined');
+    });
+
+    expect(recipeRatingComponent.ratingLabel()).toBe(
+      'Your rating: 1 out of 5 stars'
+    );
+  });
+
+  it('should fill all stars to the left if hovering', () => {
+    // Given a hovered rating
+    initializeRecipeRating({
+      averageRating: 3.5,
+      totalRatings: 4,
+      hoveringStar: 2,
+    });
+
+    // Then the first 2 stars should be filled
+    [1, 2].forEach((i) => {
+      expect(recipeRatingComponent.starIcon(i)).toBe('star');
+    });
+    [3, 4, 5].forEach((i) => {
+      expect(recipeRatingComponent.starIcon(i)).toBe('star_outlined');
+    });
+
+    expect(recipeRatingComponent.ratingLabel()).toBe(
+      'Average rating: 3.5 out of 5 stars'
+    );
+  });
+});

--- a/src/app/components/recipe-rating/recipe-rating.component.ts
+++ b/src/app/components/recipe-rating/recipe-rating.component.ts
@@ -57,6 +57,11 @@ export class RecipeRatingComponent {
     return `Rate ${stars} ${stars === 1 ? 'star' : 'stars'}`;
   }
 
+  onClick(event: MouseEvent, star_i: number) {
+    event.stopPropagation();
+    this.handleRate.emit(star_i);
+  }
+
   onHoverStart(star_i: number) {
     this.hoveringStar.set(star_i);
   }

--- a/src/app/components/recipe-rating/recipe-rating.component.ts
+++ b/src/app/components/recipe-rating/recipe-rating.component.ts
@@ -21,6 +21,8 @@ export class RecipeRatingComponent {
   hoveringStar = signal<number | undefined>(undefined);
 
   readonly RATINGS = Array.from({ length: 5 }, (_, i) => i + 1);
+  readonly AMBER_700 = '#FFA000';
+  readonly ORANGE_900 = '#E65100';
 
   starIcon(i: number) {
     // In the hovering state, always fill the stars to the left and keep the right stars empty

--- a/src/app/components/recipe-rating/recipe-rating.component.ts
+++ b/src/app/components/recipe-rating/recipe-rating.component.ts
@@ -1,0 +1,67 @@
+import { CommonModule } from '@angular/common';
+import { Component, input, output, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+import { ShorthandPipe } from '../../pipes/shorthand.pipe';
+
+@Component({
+  selector: 'app-recipe-rating',
+  imports: [CommonModule, MatButtonModule, MatIconModule, ShorthandPipe],
+  templateUrl: './recipe-rating.component.html',
+  styleUrl: './recipe-rating.component.scss',
+})
+export class RecipeRatingComponent {
+  readonly averageRating = input.required<number | undefined>();
+  readonly totalRatings = input.required<number>();
+  readonly myRating = input<number>();
+  readonly enabled = input(true);
+  readonly handleRate = output<number>();
+
+  hoveringStar = signal<number | undefined>(undefined);
+
+  readonly RATINGS = Array.from({ length: 5 }, (_, i) => i + 1);
+
+  starIcon(i: number) {
+    // In the hovering state, always fill the stars to the left and keep the right stars empty
+    const hoveringStarState = this.hoveringStar();
+    if (hoveringStarState !== undefined) {
+      return i <= hoveringStarState ? 'star' : 'star_outlined';
+    }
+
+    // If the user has rated the recipe, show their rating instead of the average
+    // If there are no ratings, show all empty stars
+    const starRating = this.myRating() ?? this.averageRating() ?? 0;
+    const stars = Math.round(starRating);
+
+    if (i < stars || (i === stars && starRating >= stars)) {
+      return 'star';
+    } else if (i === stars && starRating < stars) {
+      return 'star_half';
+    } else {
+      return 'star_outlined';
+    }
+  }
+
+  ratingLabel() {
+    if (this.myRating() !== undefined) {
+      return `Your rating: ${this.myRating()} out of 5 stars`;
+    } else if (this.averageRating() !== undefined) {
+      return `Average rating: ${this.averageRating()} out of 5 stars`;
+    } else {
+      return 'No ratings available';
+    }
+  }
+
+  starRatingInputLabel(stars: number) {
+    return `Rate ${stars} ${stars === 1 ? 'star' : 'stars'}`;
+  }
+
+  onHoverStart(star_i: number) {
+    this.hoveringStar.set(star_i);
+  }
+
+  onHoverEnd() {
+    this.hoveringStar.set(undefined);
+  }
+}

--- a/src/app/components/recipe-rating/recipe-rating.component.ts
+++ b/src/app/components/recipe-rating/recipe-rating.component.ts
@@ -12,7 +12,7 @@ import { ShorthandPipe } from '../../pipes/shorthand.pipe';
   styleUrl: './recipe-rating.component.scss',
 })
 export class RecipeRatingComponent {
-  readonly averageRating = input.required<number | undefined>();
+  readonly averageRating = input.required<number | null>();
   readonly totalRatings = input.required<number>();
   readonly myRating = input<number>();
   readonly enabled = input(true);
@@ -46,7 +46,7 @@ export class RecipeRatingComponent {
   ratingLabel() {
     if (this.myRating() !== undefined) {
       return `Your rating: ${this.myRating()} out of 5 stars`;
-    } else if (this.averageRating() !== undefined) {
+    } else if (this.averageRating() !== null) {
       return `Average rating: ${this.averageRating()} out of 5 stars`;
     } else {
       return 'No ratings available';

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -66,15 +66,21 @@
       }
     </mat-chip-set>
 
-    <h2 class="recipe-time" [ngPlural]="recipe.time">
-      <!-- Pluralize the recipe time (if a recipe only takes a minute) -->
-      <ng-template ngPluralCase="1">
-        <b>Time:</b> {{ recipe.time }} minute
-      </ng-template>
-      <ng-template ngPluralCase="other">
-        <b>Time:</b> {{ recipe.time }} minutes
-      </ng-template>
-    </h2>
+    <div class="recipe-time-container">
+      <h2 class="recipe-time" [ngPlural]="recipe.time">
+        <!-- Pluralize the recipe time (if a recipe only takes a minute) -->
+        <ng-template ngPluralCase="1">
+          <b>Time:</b> {{ recipe.time }} minute
+        </ng-template>
+        <ng-template ngPluralCase="other">
+          <b>Time:</b> {{ recipe.time }} minutes
+        </ng-template>
+      </h2>
+      <div class="recipe-views">
+        <mat-icon fontIcon="visibility" aria-label="views" />
+        {{ recipe.views ?? 0 | shorthand }}
+      </div>
+    </div>
 
     @if (recipe.types.length > 0) {
     <h3 class="recipe-types">

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -82,6 +82,13 @@
       </div>
     </div>
 
+    <app-recipe-rating
+      [averageRating]="recipe.averageRating"
+      [totalRatings]="recipe.totalRatings ?? 0"
+      [myRating]=""
+      (handleRate)="onRate($event)"
+    />
+
     @if (recipe.types.length > 0) {
     <h3 class="recipe-types">
       <b>Great for:</b> {{ recipe.types.join(", ") }}

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -1,15 +1,15 @@
-@if (isLoading) {
+@if (isLoading()) {
 <mat-spinner diameter="50" class="progress-spinner" />
-} @if (recipe !== null) {
+} @if (recipe() !== null) {
 <!-- Recipe header -->
 <header class="recipe-header">
   <!-- Show the recipe name and a link to its source next to it -->
-  <h1 class="recipe-name">{{ recipe.name | titlecase }}</h1>
-  @if (recipe.url !== undefined) {
+  <h1 class="recipe-name">{{ recipe()?.name | titlecase }}</h1>
+  @if (recipe()?.url !== undefined) {
   <a
     mat-icon-button
     class="recipe-link"
-    [href]="recipe.url"
+    [href]="recipe()?.url"
     target="_blank"
     rel="noopener noreferrer"
     aria-label="Open recipe source"
@@ -25,15 +25,19 @@
     <figure class="recipe-figure">
       <img
         class="recipe-image"
-        [src]="recipe.image"
-        [alt]="recipe.name"
+        [src]="recipe()?.image"
+        [alt]="recipe()?.name"
         width="312"
         height="231"
       />
       <figcaption class="recipe-caption mat-caption">
         Image ©
-        <a [href]="recipe.sourceUrl" target="_blank" rel="noopener noreferrer">
-          {{ recipe.credit }}
+        <a
+          [href]="recipe()?.sourceUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ recipe()?.credit }}
         </a>
       </figcaption>
     </figure>
@@ -41,61 +45,61 @@
     <!-- Recipe info -->
     <mat-chip-set class="recipe-pill-list">
       <!-- Don't make the chips clickable, but still show their color -->
-      @if (['mild', 'spicy'].includes(recipe.spiceLevel)) {
+      @if (['mild', 'spicy'].includes(recipe()!.spiceLevel)) {
       <mat-chip
         [ngStyle]="{
           'background-color':
-            recipe.spiceLevel === 'mild' ? 'orange' : '#f44326'
+            recipe()?.spiceLevel === 'mild' ? 'orange' : '#f44326'
         }"
         disableRipple
       >
-        {{ recipe.spiceLevel | titlecase }}
+        {{ recipe()?.spiceLevel | titlecase }}
       </mat-chip>
-      } @if (recipe.isVegetarian) {
+      } @if (recipe()?.isVegetarian) {
       <mat-chip disableRipple>Vegetarian</mat-chip>
-      } @if (recipe.isVegan) {
+      } @if (recipe()?.isVegan) {
       <mat-chip disableRipple>Vegan</mat-chip>
-      } @if (recipe.isGlutenFree) {
+      } @if (recipe()?.isGlutenFree) {
       <mat-chip disableRipple>Gluten-Free</mat-chip>
-      } @if (recipe.isHealthy) {
+      } @if (recipe()?.isHealthy) {
       <mat-chip disableRipple>Healthy</mat-chip>
-      } @if (recipe.isCheap) {
+      } @if (recipe()?.isCheap) {
       <mat-chip disableRipple>Cheap</mat-chip>
-      } @if (recipe.isSustainable) {
+      } @if (recipe()?.isSustainable) {
       <mat-chip disableRipple>Sustainable</mat-chip>
       }
     </mat-chip-set>
 
     <div class="recipe-time-container">
-      <h2 class="recipe-time" [ngPlural]="recipe.time">
+      <h2 class="recipe-time" [ngPlural]="recipe()!.time">
         <!-- Pluralize the recipe time (if a recipe only takes a minute) -->
         <ng-template ngPluralCase="1">
-          <b>Time:</b> {{ recipe.time }} minute
+          <b>Time:</b> {{ recipe()?.time }} minute
         </ng-template>
         <ng-template ngPluralCase="other">
-          <b>Time:</b> {{ recipe.time }} minutes
+          <b>Time:</b> {{ recipe()?.time }} minutes
         </ng-template>
       </h2>
       <div class="recipe-views">
         <mat-icon fontIcon="visibility" aria-label="views" />
-        {{ recipe.views ?? 0 | shorthand }}
+        {{ recipe()?.views ?? 0 | shorthand }}
       </div>
     </div>
 
     <app-recipe-rating
-      [averageRating]="recipe.averageRating ?? null"
-      [totalRatings]="recipe.totalRatings ?? 0"
-      [myRating]="chef()?.ratings?.[recipe.id]"
+      [averageRating]="recipe()?.averageRating ?? null"
+      [totalRatings]="recipe()?.totalRatings ?? 0"
+      [myRating]="chef()?.ratings?.[recipe()!.id]"
       (handleRate)="onRate($event)"
     />
 
-    @if (recipe.types.length > 0) {
+    @if ((recipe()?.types?.length ?? 0) > 0) {
     <h3 class="recipe-types">
-      <b>Great for:</b> {{ recipe.types.join(", ") }}
+      <b>Great for:</b> {{ recipe()?.types?.join(", ") }}
     </h3>
-    } @if (recipe.culture.length > 0) {
+    } @if ((recipe()?.culture?.length ?? 0) > 0) {
     <h3 class="recipe-culture">
-      <b>Cuisines:</b> {{ recipe.culture.join(", ") }}
+      <b>Cuisines:</b> {{ recipe()?.culture?.join(", ") }}
     </h3>
     }
 
@@ -107,7 +111,7 @@
           class="show-recipe-button"
           aria-label="Show me another recipe"
           (click)="getRandomRecipe()"
-          [disabled]="isLoading"
+          [disabled]="isLoading()"
         >
           <mat-icon fontIcon="receipt_long" />
         </button>
@@ -121,22 +125,22 @@
     <mat-card-header class="nutrition-card-header">
       <mat-card-title>Nutrition Facts</mat-card-title>
       <mat-card-subtitle
-        >Health Score: {{ recipe.healthScore }}%</mat-card-subtitle
+        >Health Score: {{ recipe()?.healthScore }}%</mat-card-subtitle
       >
       <!-- Change the output based on whether there is more than 1 serving -->
-      <mat-card-subtitle [ngPlural]="recipe.servings">
+      <mat-card-subtitle [ngPlural]="recipe()!.servings">
         <ng-template ngPluralCase="1">
-          {{ recipe.servings }} serving
+          {{ recipe()?.servings }} serving
         </ng-template>
         <ng-template ngPluralCase="other">
-          {{ recipe.servings }} servings
+          {{ recipe()?.servings }} servings
         </ng-template>
       </mat-card-subtitle>
     </mat-card-header>
     <mat-divider class="nutrient-divider" />
     <mat-card-content>
       <div class="nutrient-grid">
-        @for (nutrient of recipe.nutrients; track nutrient.name) {
+        @for (nutrient of recipe()?.nutrients; track nutrient.name) {
         <p
           class="nutrient-name"
           [ngClass]="{
@@ -172,7 +176,7 @@
       />
     </mat-card-header>
     <!-- Render HTML tags -->
-    <mat-card-content [innerHtml]="recipe.summary" />
+    <mat-card-content [innerHtml]="recipe()?.summary" />
   </mat-card>
 
   <!-- Ingredients -->
@@ -183,16 +187,16 @@
     <mat-divider class="ingredient-divider" />
     <mat-card-content>
       <div class="ingredient-grid">
-        @for (ingredient of recipe.ingredients; track ingredient.id) {
+        @for (ingredient of recipe()?.ingredients; track ingredient.id) {
         <p class="ingredient-amount">
           {{ ingredient.amount }} {{ ingredient.unit }}
         </p>
         <p class="ingredient-name">
           @for (word of ingredient.name.split(' '); track $index) {
           <!-- Capitalize the ingredient names -->
-          @if (dictionary !== undefined &&
-          dictionary.hasOwnProperty(word.toLowerCase())) {
-          <span class="term" [matTooltip]="dictionary[word.toLowerCase()]"
+          @if (dictionary() !== undefined &&
+          dictionary()?.hasOwnProperty(word.toLowerCase())) {
+          <span class="term" [matTooltip]="dictionary()?.[word.toLowerCase()]"
             >{{ word | titlecase }}
           </span>
           } @else {
@@ -209,7 +213,7 @@
   <!-- Steps -->
   <h2 class="steps-header">Steps</h2>
   <!-- If applicable, split each instruction into separate sections -->
-  @for (instruction of recipe.instructions; track $index) {
+  @for (instruction of recipe()?.instructions; track $index) {
   <div class="instructions-container">
     <h3 class="instruction-header">{{ instruction.name }}</h3>
     <!-- Display each step in a grid -->
@@ -223,9 +227,11 @@
             <p>
               @for (word of step.step.split(' '); track $index) {
               <!-- Can't use the "in" operator -->
-              @if (dictionary !== undefined &&
-              dictionary.hasOwnProperty(word.toLowerCase())) {
-              <span class="term" [matTooltip]="dictionary[word.toLowerCase()]"
+              @if (dictionary() !== undefined &&
+              dictionary()?.hasOwnProperty(word.toLowerCase())) {
+              <span
+                class="term"
+                [matTooltip]="dictionary()?.[word.toLowerCase()]"
                 >{{ word }}
               </span>
               } @else {

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -85,7 +85,7 @@
     <app-recipe-rating
       [averageRating]="recipe.averageRating ?? null"
       [totalRatings]="recipe.totalRatings ?? 0"
-      [myRating]=""
+      [myRating]="chef()?.ratings?.[recipe.id]"
       (handleRate)="onRate($event)"
     />
 

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -100,17 +100,6 @@
     }
 
     <div class="share-button-container">
-      <div class="made-container">
-        <button
-          mat-mini-fab
-          color="warn"
-          aria-label="I made this"
-          (click)="addPreparation()"
-        >
-          <mat-icon fontIcon="restaurant" />
-        </button>
-        <p>I Made This!</p>
-      </div>
       <div class="show-recipe-container">
         <button
           mat-mini-fab

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -89,7 +89,7 @@
     <app-recipe-rating
       [averageRating]="recipe()?.averageRating ?? null"
       [totalRatings]="recipe()?.totalRatings ?? 0"
-      [myRating]="chef()?.ratings?.[recipe()!.id]"
+      [myRating]="chef()?.ratings?.[recipe()!.id] ?? undefined"
       (handleRate)="onRate($event)"
     />
 

--- a/src/app/components/recipe/recipe.component.html
+++ b/src/app/components/recipe/recipe.component.html
@@ -83,7 +83,7 @@
     </div>
 
     <app-recipe-rating
-      [averageRating]="recipe.averageRating"
+      [averageRating]="recipe.averageRating ?? null"
       [totalRatings]="recipe.totalRatings ?? 0"
       [myRating]=""
       (handleRate)="onRate($event)"

--- a/src/app/components/recipe/recipe.component.scss
+++ b/src/app/components/recipe/recipe.component.scss
@@ -66,6 +66,8 @@ $blue-400: #42a5f5;
     .recipe-time-container {
       display: flex;
       justify-content: space-between;
+      margin-left: 16px;
+      margin-right: 16px;
 
       .recipe-time {
         text-align: center;

--- a/src/app/components/recipe/recipe.component.scss
+++ b/src/app/components/recipe/recipe.component.scss
@@ -63,10 +63,21 @@ $blue-400: #42a5f5;
       }
     }
 
-    .recipe-time {
-      text-align: center;
-      font-weight: normal;
-      margin-bottom: 0;
+    .recipe-time-container {
+      display: flex;
+      justify-content: space-between;
+
+      .recipe-time {
+        text-align: center;
+        font-weight: normal;
+        margin-bottom: 0;
+      }
+
+      .recipe-views {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
     }
 
     .recipe-types,

--- a/src/app/components/recipe/recipe.component.scss
+++ b/src/app/components/recipe/recipe.component.scss
@@ -91,7 +91,6 @@ $blue-400: #42a5f5;
       gap: 10px;
       margin-top: 8px;
 
-      .made-container,
       .show-recipe-container {
         display: flex;
         flex-direction: column;

--- a/src/app/components/recipe/recipe.component.spec.ts
+++ b/src/app/components/recipe/recipe.component.spec.ts
@@ -13,6 +13,7 @@ import { RouterModule } from '@angular/router';
 
 import { mockRecipe } from '../../models/recipe.mock';
 import { RecipeComponent } from './recipe.component';
+import { ShorthandPipe } from 'src/app/pipes/shorthand.pipe';
 
 describe('RecipeComponent', () => {
   let recipeComponent: RecipeComponent;
@@ -58,7 +59,7 @@ describe('RecipeComponent', () => {
     const recipeLink =
       rootElement.querySelector<HTMLAnchorElement>('.recipe-link');
     expect(recipeLink).not.toBeNull();
-    expect(recipeLink?.href).toBe(recipeComponent.recipe()!.url);
+    expect(recipeLink?.href).toBe(recipeComponent.recipe()?.url);
     expect(recipeLink?.ariaLabel).toBe('Open recipe source');
     expectLinkToOpenInNewTab(recipeLink!);
   });
@@ -68,12 +69,12 @@ describe('RecipeComponent', () => {
     // Check the recipe image and caption
     const recipeImage =
       rootElement.querySelector<HTMLImageElement>('.recipe-image');
-    expect(recipeImage?.src).toBe(recipeComponent.recipe()!.image);
-    expect(recipeImage?.alt).toBe(recipeComponent.recipe()!.name);
+    expect(recipeImage?.src).toBe(recipeComponent.recipe()?.image);
+    expect(recipeImage?.alt).toBe(recipeComponent.recipe()?.name);
     const recipeCaption =
       rootElement.querySelector<HTMLElement>('.recipe-caption');
     expect(recipeCaption?.textContent).toContain(
-      recipeComponent.recipe()!.credit
+      recipeComponent.recipe()?.credit
     );
     const recipeCaptionLink =
       recipeCaption?.firstElementChild as HTMLAnchorElement;
@@ -92,32 +93,32 @@ describe('RecipeComponent', () => {
         capitalize(recipeComponent.recipe()!.spiceLevel)
       );
     }
-    if (recipeComponent.recipe()!.isVegetarian) {
+    if (recipeComponent.recipe()?.isVegetarian) {
       expect(recipePills?.textContent).toContain('Vegetarian');
     } else {
       expect(recipePills?.textContent).not.toContain('Vegetarian');
     }
-    if (recipeComponent.recipe()!.isVegan) {
+    if (recipeComponent.recipe()?.isVegan) {
       expect(recipePills?.textContent).toContain('Vegan');
     } else {
       expect(recipePills?.textContent).not.toContain('Vegan');
     }
-    if (recipeComponent.recipe()!.isGlutenFree) {
+    if (recipeComponent.recipe()?.isGlutenFree) {
       expect(recipePills?.textContent).toContain('Gluten-Free');
     } else {
       expect(recipePills?.textContent).not.toContain('Gluten-Free');
     }
-    if (recipeComponent.recipe()!.isHealthy) {
+    if (recipeComponent.recipe()?.isHealthy) {
       expect(recipePills?.textContent).toContain('Healthy');
     } else {
       expect(recipePills?.textContent).not.toContain('Healthy');
     }
-    if (recipeComponent.recipe()!.isCheap) {
+    if (recipeComponent.recipe()?.isCheap) {
       expect(recipePills?.textContent).toContain('Cheap');
     } else {
       expect(recipePills?.textContent).not.toContain('Cheap');
     }
-    if (recipeComponent.recipe()!.isSustainable) {
+    if (recipeComponent.recipe()?.isSustainable) {
       expect(recipePills?.textContent).toContain('Sustainable');
     } else {
       expect(recipePills?.textContent).not.toContain('Sustainable');
@@ -127,7 +128,15 @@ describe('RecipeComponent', () => {
     const recipeTime =
       rootElement.querySelector<HTMLHeadingElement>('.recipe-time');
     expect(recipeTime?.textContent).toContain(
-      `${recipeComponent.recipe()!.time} minutes`
+      `${recipeComponent.recipe()?.time} minutes`
+    );
+    // The recipe views should be in shorthand
+    const recipeViews =
+      rootElement.querySelector<HTMLDivElement>('.recipe-views');
+    const shorthandPipe = new ShorthandPipe();
+    expect(recipeComponent.recipe()?.views).not.toBeUndefined();
+    expect(recipeViews?.textContent).toContain(
+      shorthandPipe.transform(recipeComponent.recipe()!.views!)
     );
 
     // The recipe types & culture should be listed if applicable
@@ -155,11 +164,11 @@ describe('RecipeComponent', () => {
       rootElement.querySelector<HTMLElement>('.nutrition-card');
     expect(nutritionCard?.textContent).toContain('Nutrition Facts');
     expect(nutritionCard?.textContent).toContain(
-      recipeComponent.recipe()!.healthScore
+      recipeComponent.recipe()?.healthScore
     );
     // Servings should be plural if > 1
     expect(nutritionCard?.textContent).toContain(
-      `${recipeComponent.recipe()!.servings} servings`
+      `${recipeComponent.recipe()?.servings} servings`
     );
 
     // Each nutrient should be displayed
@@ -181,7 +190,7 @@ describe('RecipeComponent', () => {
     );
     expect(recipeSummaryCard?.textContent).toContain('Summary');
     expect(recipeSummaryCard?.innerHTML).toContain(
-      recipeComponent.recipe()!.summary
+      recipeComponent.recipe()?.summary
     );
 
     const lightBulbIcon =

--- a/src/app/components/recipe/recipe.component.spec.ts
+++ b/src/app/components/recipe/recipe.component.spec.ts
@@ -31,7 +31,7 @@ describe('RecipeComponent', () => {
     fixture = TestBed.createComponent(RecipeComponent);
     fixture.detectChanges();
     recipeComponent = fixture.componentInstance;
-    recipeComponent.recipe = mockRecipe;
+    recipeComponent.recipe.set(mockRecipe);
     rootElement = fixture.nativeElement;
     fixture.detectChanges();
   });
@@ -53,12 +53,12 @@ describe('RecipeComponent', () => {
     const recipeName =
       rootElement.querySelector<HTMLHeadingElement>('.recipe-name');
     // The recipe name should be capitalized
-    const capitalizedName = capitalize(recipeComponent.recipe!.name);
+    const capitalizedName = capitalize(recipeComponent.recipe()!.name);
     expect(recipeName?.textContent).toBe(capitalizedName);
     const recipeLink =
       rootElement.querySelector<HTMLAnchorElement>('.recipe-link');
     expect(recipeLink).not.toBeNull();
-    expect(recipeLink?.href).toBe(recipeComponent.recipe!.url);
+    expect(recipeLink?.href).toBe(recipeComponent.recipe()!.url);
     expect(recipeLink?.ariaLabel).toBe('Open recipe source');
     expectLinkToOpenInNewTab(recipeLink!);
   });
@@ -68,56 +68,56 @@ describe('RecipeComponent', () => {
     // Check the recipe image and caption
     const recipeImage =
       rootElement.querySelector<HTMLImageElement>('.recipe-image');
-    expect(recipeImage?.src).toBe(recipeComponent.recipe!.image);
-    expect(recipeImage?.alt).toBe(recipeComponent.recipe!.name);
+    expect(recipeImage?.src).toBe(recipeComponent.recipe()!.image);
+    expect(recipeImage?.alt).toBe(recipeComponent.recipe()!.name);
     const recipeCaption =
       rootElement.querySelector<HTMLElement>('.recipe-caption');
     expect(recipeCaption?.textContent).toContain(
-      recipeComponent.recipe!.credit
+      recipeComponent.recipe()!.credit
     );
     const recipeCaptionLink =
       recipeCaption?.firstElementChild as HTMLAnchorElement;
-    expect(recipeCaptionLink.href).toBe(recipeComponent.recipe!.sourceUrl);
+    expect(recipeCaptionLink.href).toBe(recipeComponent.recipe()!.sourceUrl);
     expectLinkToOpenInNewTab(recipeCaptionLink);
 
     // The recipe pills should show if applicable
     const recipePills =
       rootElement.querySelector<HTMLElement>('.recipe-pill-list');
-    if (['mild', 'spicy'].includes(recipeComponent.recipe!.spiceLevel)) {
+    if (['mild', 'spicy'].includes(recipeComponent.recipe()!.spiceLevel)) {
       expect(recipePills?.textContent).toContain(
-        capitalize(recipeComponent.recipe!.spiceLevel)
+        capitalize(recipeComponent.recipe()!.spiceLevel)
       );
     } else {
       expect(recipePills?.textContent).not.toContain(
-        capitalize(recipeComponent.recipe!.spiceLevel)
+        capitalize(recipeComponent.recipe()!.spiceLevel)
       );
     }
-    if (recipeComponent.recipe!.isVegetarian) {
+    if (recipeComponent.recipe()!.isVegetarian) {
       expect(recipePills?.textContent).toContain('Vegetarian');
     } else {
       expect(recipePills?.textContent).not.toContain('Vegetarian');
     }
-    if (recipeComponent.recipe!.isVegan) {
+    if (recipeComponent.recipe()!.isVegan) {
       expect(recipePills?.textContent).toContain('Vegan');
     } else {
       expect(recipePills?.textContent).not.toContain('Vegan');
     }
-    if (recipeComponent.recipe!.isGlutenFree) {
+    if (recipeComponent.recipe()!.isGlutenFree) {
       expect(recipePills?.textContent).toContain('Gluten-Free');
     } else {
       expect(recipePills?.textContent).not.toContain('Gluten-Free');
     }
-    if (recipeComponent.recipe!.isHealthy) {
+    if (recipeComponent.recipe()!.isHealthy) {
       expect(recipePills?.textContent).toContain('Healthy');
     } else {
       expect(recipePills?.textContent).not.toContain('Healthy');
     }
-    if (recipeComponent.recipe!.isCheap) {
+    if (recipeComponent.recipe()!.isCheap) {
       expect(recipePills?.textContent).toContain('Cheap');
     } else {
       expect(recipePills?.textContent).not.toContain('Cheap');
     }
-    if (recipeComponent.recipe!.isSustainable) {
+    if (recipeComponent.recipe()!.isSustainable) {
       expect(recipePills?.textContent).toContain('Sustainable');
     } else {
       expect(recipePills?.textContent).not.toContain('Sustainable');
@@ -127,7 +127,7 @@ describe('RecipeComponent', () => {
     const recipeTime =
       rootElement.querySelector<HTMLHeadingElement>('.recipe-time');
     expect(recipeTime?.textContent).toContain(
-      `${recipeComponent.recipe!.time} minutes`
+      `${recipeComponent.recipe()!.time} minutes`
     );
 
     // The recipe types & culture should be listed if applicable
@@ -135,10 +135,10 @@ describe('RecipeComponent', () => {
       rootElement.querySelector<HTMLHeadingElement>('.recipe-types');
     const recipeCulture =
       rootElement.querySelector<HTMLHeadingElement>('.recipe-culture');
-    for (const type of recipeComponent.recipe!.types) {
+    for (const type of recipeComponent.recipe()!.types) {
       expect(recipeTypes?.textContent).toContain(type);
     }
-    for (const culture of recipeComponent.recipe!.culture) {
+    for (const culture of recipeComponent.recipe()!.culture) {
       expect(recipeCulture?.textContent).toContain(culture);
     }
 
@@ -155,17 +155,17 @@ describe('RecipeComponent', () => {
       rootElement.querySelector<HTMLElement>('.nutrition-card');
     expect(nutritionCard?.textContent).toContain('Nutrition Facts');
     expect(nutritionCard?.textContent).toContain(
-      recipeComponent.recipe!.healthScore
+      recipeComponent.recipe()!.healthScore
     );
     // Servings should be plural if > 1
     expect(nutritionCard?.textContent).toContain(
-      `${recipeComponent.recipe!.servings} servings`
+      `${recipeComponent.recipe()!.servings} servings`
     );
 
     // Each nutrient should be displayed
     const nutritionGrid =
       nutritionCard?.querySelector<HTMLDivElement>('.nutrient-grid');
-    for (const nutrient of recipeComponent.recipe!.nutrients) {
+    for (const nutrient of recipeComponent.recipe()!.nutrients) {
       expect(nutritionGrid?.textContent).toContain(nutrient.name);
       // The nutrient amount should be rounded to the nearest whole number
       const roundedAmount = Math.round(nutrient.amount);
@@ -181,7 +181,7 @@ describe('RecipeComponent', () => {
     );
     expect(recipeSummaryCard?.textContent).toContain('Summary');
     expect(recipeSummaryCard?.innerHTML).toContain(
-      recipeComponent.recipe!.summary
+      recipeComponent.recipe()!.summary
     );
 
     const lightBulbIcon =
@@ -196,7 +196,7 @@ describe('RecipeComponent', () => {
 
     const ingredientGrid =
       ingredientsCard?.querySelector<HTMLDivElement>('.ingredient-grid');
-    for (const ingredient of recipeComponent.recipe!.ingredients) {
+    for (const ingredient of recipeComponent.recipe()!.ingredients) {
       // The ingredient name should be capitalized
       const capitalizedName = capitalize(ingredient.name);
       expect(ingredientGrid?.textContent).toContain(capitalizedName);
@@ -211,10 +211,9 @@ describe('RecipeComponent', () => {
       rootElement.querySelector<HTMLHeadingElement>('.steps-header');
     expect(stepsHeader?.textContent).toContain('Steps');
 
-    for (const [
-      instructionIndex,
-      instruction,
-    ] of recipeComponent.recipe!.instructions.entries()) {
+    for (const [instructionIndex, instruction] of recipeComponent
+      .recipe()!
+      .instructions.entries()) {
       const instructionsContainer =
         rootElement.querySelectorAll<HTMLDivElement>('.instructions-container')[
           instructionIndex
@@ -284,7 +283,7 @@ describe('RecipeComponent', () => {
 
   it('should show a spinner while loading', () => {
     // Check that the material spinner shows when isLoading is true
-    recipeComponent.isLoading = true;
+    recipeComponent.isLoading.set(true);
     fixture.detectChanges();
     expect(rootElement.querySelector('.progress-spinner')).not.toBeNull();
     // The show recipe button should be disabled

--- a/src/app/components/recipe/recipe.component.spec.ts
+++ b/src/app/components/recipe/recipe.component.spec.ts
@@ -142,10 +142,7 @@ describe('RecipeComponent', () => {
       expect(recipeCulture?.textContent).toContain(culture);
     }
 
-    // The "I Made This!" and "Show Me Another Recipe!" buttons should be present
-    const madeContainer =
-      rootElement.querySelector<HTMLDivElement>('.made-container');
-    expect(madeContainer?.textContent).toContain('I Made This!');
+    // The "Show Me Another Recipe!" button should be present
     const showRecipeContainer = rootElement.querySelector<HTMLDivElement>(
       '.show-recipe-container'
     );

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -143,13 +143,14 @@ export class RecipeComponent implements OnInit, OnDestroy {
       .getRecipeById(id)
       .subscribe({
         next: (recipe: Recipe) => {
-          this.isLoading = false;
           this.recipeService.setRecipe(recipe);
           console.log(recipe);
         },
         error: (error: Error) => {
-          this.isLoading = false;
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading = false;
         },
       });
   }
@@ -209,7 +210,6 @@ export class RecipeComponent implements OnInit, OnDestroy {
       .getRandomRecipe()
       .subscribe({
         next: (recipe: Recipe) => {
-          this.isLoading = false;
           this.updateRecipe(recipe);
           console.log(recipe);
           // Change the URL without reloading the component
@@ -217,8 +217,10 @@ export class RecipeComponent implements OnInit, OnDestroy {
         },
         error: (error: Error) => {
           // Show a snackbar explaining that an error occurred
-          this.isLoading = false;
           this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
+          this.isLoading = false;
         },
       });
   }

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -150,13 +150,6 @@ export class RecipeComponent implements OnInit, OnDestroy {
       });
   }
 
-  addPreparation() {
-    // Placeholder for the "I Made This!" button
-    this.snackBar.open('Nice! Hope it was tasty!', undefined, {
-      duration: 2000, // automatically dismiss after 2 seconds
-    });
-  }
-
   onRate(rating: number) {
     console.log('clicked rating:', rating);
   }

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -16,6 +16,7 @@ import Recipe from '../../models/recipe.model';
 import { RecipeService } from '../../services/recipe.service';
 import { TermsService } from 'src/app/services/terms.service';
 import { ShorthandPipe } from '../../pipes/shorthand.pipe';
+import { RecipeRatingComponent } from '../recipe-rating/recipe-rating.component';
 
 @Component({
   selector: 'app-recipe',
@@ -28,6 +29,7 @@ import { ShorthandPipe } from '../../pipes/shorthand.pipe';
     MatIconModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
+    RecipeRatingComponent,
     ShorthandPipe,
   ],
   templateUrl: './recipe.component.html',
@@ -153,6 +155,10 @@ export class RecipeComponent implements OnInit, OnDestroy {
     this.snackBar.open('Nice! Hope it was tasty!', undefined, {
       duration: 2000, // automatically dismiss after 2 seconds
     });
+  }
+
+  onRate(rating: number) {
+    console.log('clicked rating:', rating);
   }
 
   getRandomRecipe() {

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -215,15 +215,9 @@ export class RecipeComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.isLoading.set(true);
     this.recipeService
       .updateRecipe(recipeId, recipeUpdate, token)
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        finalize(() => {
-          this.isLoading.set(false);
-        })
-      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: ({ token }) => {
           this.chefService.chef.update(

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -15,6 +15,7 @@ import { Subscription } from 'rxjs';
 import Recipe from '../../models/recipe.model';
 import { RecipeService } from '../../services/recipe.service';
 import { TermsService } from 'src/app/services/terms.service';
+import { ShorthandPipe } from '../../pipes/shorthand.pipe';
 
 @Component({
   selector: 'app-recipe',
@@ -27,6 +28,7 @@ import { TermsService } from 'src/app/services/terms.service';
     MatIconModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
+    ShorthandPipe,
   ],
   templateUrl: './recipe.component.html',
   styleUrl: './recipe.component.scss',

--- a/src/app/components/search/search.component.html
+++ b/src/app/components/search/search.component.html
@@ -132,17 +132,17 @@
       color="accent"
       type="submit"
       class="submit-button"
-      [disabled]="!filterFormGroup.valid || isLoading"
+      [disabled]="!filterFormGroup.valid || isLoading()"
     >
       Apply
     </button>
-    @if (isLoading) {
+    @if (isLoading()) {
     <mat-spinner diameter="40" class="progress-spinner" />
     }
   </span>
-  @if (isLoading) {
-  <p class="loading-message">{{ loadingMessage }}</p>
-  } @if (noRecipesFound) {
+  @if (isLoading()) {
+  <p class="loading-message">{{ loadingMessage() }}</p>
+  } @if (noRecipesFound()) {
   <p class="no-results-error">
     <mat-icon fontIcon="error" />{{ Errors.noResults }}
   </p>
@@ -150,18 +150,18 @@
 </form>
 
 <!-- Results -->
-@if (recipes.length > 0) {
+@if (recipes().length > 0) {
 <section class="results">
   <mat-divider class="results-divider" />
   <h1 class="results-title">Results</h1>
   <ul class="results-list">
-    @for (recipe of recipes; track recipe.id) {
+    @for (recipe of recipes(); track recipe.id) {
     <li>
       <app-recipe-card [recipe]="recipe" />
     </li>
     }
   </ul>
-  @if (isLoading) {
+  @if (isLoading()) {
   <mat-spinner diameter="40" class="progress-spinner" />
   }
 </section>

--- a/src/app/components/search/search.component.spec.ts
+++ b/src/app/components/search/search.component.spec.ts
@@ -129,9 +129,9 @@ describe('SearchComponent', () => {
     });
     expect(searchComponent.filterFormGroup.valid).toBeTrue();
 
-    expect(searchComponent.isLoading).toBeFalse();
-    expect(searchComponent.loadingMessage).toBe('');
-    expect(searchComponent.noRecipesFound).toBeFalse();
+    expect(searchComponent.isLoading()).toBeFalse();
+    expect(searchComponent.loadingMessage()).toBe('');
+    expect(searchComponent.noRecipesFound()).toBeFalse();
   });
 
   it('should show an error if the calories are less than the min', () => {
@@ -264,7 +264,7 @@ describe('SearchComponent', () => {
 
   it('should show a spinner while loading', () => {
     // Check that the material spinner shows when isLoading is true
-    searchComponent.isLoading = true;
+    searchComponent.isLoading.set(true);
     fixture.detectChanges();
 
     expect(rootElement.querySelector('.progress-spinner')).not.toBeNull();
@@ -277,7 +277,7 @@ describe('SearchComponent', () => {
 
   it('should show an error if no recipes were found', () => {
     // Check that the noRecipesFound error appears
-    searchComponent.noRecipesFound = true;
+    searchComponent.noRecipesFound.set(true);
     fixture.detectChanges();
 
     const noResultsError =
@@ -320,14 +320,16 @@ describe('SearchComponent', () => {
   it('should show a random message while loading', () => {
     // The loading message should start blank, then show a random message after some time
     searchComponent.showLoadingMessages();
-    expect(searchComponent.loadingMessage).toBe('');
+    expect(searchComponent.loadingMessage()).toBe('');
     jasmine.clock().tick(3000);
-    expect(Constants.loadingMessages).toContain(searchComponent.loadingMessage);
+    expect(Constants.loadingMessages).toContain(
+      searchComponent.loadingMessage()
+    );
   });
 
   it('shows results if there are recipes', () => {
     // The results section should show if there's at least one recipe
-    searchComponent.recipes = mockRecipes;
+    searchComponent.recipes.set(mockRecipes);
     fixture.detectChanges();
 
     const resultsTitle =

--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -101,8 +101,8 @@ const calorieRangeValidator: ValidatorFn = (
     MatProgressSpinnerModule,
     MatSelectModule,
     ReactiveFormsModule,
-    RecipeCardComponent
-],
+    RecipeCardComponent,
+  ],
   templateUrl: './search.component.html',
   styleUrl: './search.component.scss',
   animations: [
@@ -261,8 +261,6 @@ export class SearchComponent implements OnInit, OnDestroy {
       .getRecipesWithFilter(recipeFilter)
       .subscribe({
         next: (recipes: Recipe[]) => {
-          this.isLoading = false;
-          clearInterval(timer);
           // Append results if paginating, replace otherwise
           this.recipes = paginate ? this.recipes.concat(recipes) : recipes;
           // Don't show an error if there are no more paginated results
@@ -277,9 +275,11 @@ export class SearchComponent implements OnInit, OnDestroy {
           }
         },
         error: (error: Error) => {
+          this.snackBar.open(error.message, 'Dismiss');
+        },
+        complete: () => {
           this.isLoading = false;
           clearInterval(timer);
-          this.snackBar.open(error.message, 'Dismiss');
         },
       });
   }

--- a/src/app/models/recipe.model.ts
+++ b/src/app/models/recipe.model.ts
@@ -136,9 +136,10 @@ type Recipe = {
       }[];
     }[];
   }[];
+  // Newly added fields are undefined for existing recipes
   token?: string; // searchSequenceToken for pagination
   totalRatings?: number;
-  averageRating?: number;
+  averageRating?: number | null;
   views?: number;
 };
 

--- a/src/app/pipes/shorthand.pipe.spec.ts
+++ b/src/app/pipes/shorthand.pipe.spec.ts
@@ -1,0 +1,34 @@
+import { ShorthandPipe } from './shorthand.pipe';
+
+describe('ShorthandPipe', () => {
+  let pipe: ShorthandPipe;
+
+  beforeEach(() => {
+    pipe = new ShorthandPipe();
+  });
+
+  it('creates an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  (
+    [
+      [0, '0'],
+      [1, '1'],
+      [999, '999'],
+      [1000, '1K'],
+      [1234, '1.2K'],
+      [999999, '1M'],
+      [1000000, '1M'],
+      [1234567, '1.2M'],
+      [999999999, '1B'],
+      [1000000000, '1B'],
+      [1234567890, '1.2B'],
+    ] as [number, string][]
+  ).forEach(([num, expectedValue]) => {
+    it(`converts ${num} to shorthand ${expectedValue}`, () => {
+      const actualValue = pipe.transform(num);
+      expect(actualValue).toBe(expectedValue);
+    });
+  });
+});

--- a/src/app/pipes/shorthand.pipe.ts
+++ b/src/app/pipes/shorthand.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'shorthand',
+})
+export class ShorthandPipe implements PipeTransform {
+  /**
+   * Convert a number to a shorthand string (e.g., 1234 --> 1.2K)
+   */
+  transform(value: number): string {
+    return Intl.NumberFormat('en', { notation: 'compact' }).format(value);
+  }
+}

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -67,6 +67,7 @@ describe('ChefService', () => {
     req.flush(mockChef);
 
     await expectAsync(chefPromise).toBeResolvedTo(mockChef);
+    expect(chefService.chef()).toBe(mockChef);
   });
 
   it('should return an error if the GET chef API fails', async () => {
@@ -79,6 +80,7 @@ describe('ChefService', () => {
     req.error(mockError);
 
     await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
+    expect(chefService.chef()).toBeUndefined();
   });
 
   it('should create a chef', async () => {
@@ -94,9 +96,19 @@ describe('ChefService', () => {
     });
     expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(credentials);
-    req.flush(mockLoginResponse());
+    const loginResponse = mockLoginResponse(false);
+    req.flush(loginResponse);
 
-    await expectAsync(chefPromise).toBeResolvedTo(mockLoginResponse());
+    await expectAsync(chefPromise).toBeResolvedTo(loginResponse);
+    expect(chefService.chef()).toEqual({
+      uid: loginResponse.uid,
+      email: credentials.email,
+      emailVerified: false,
+      ratings: {},
+      recentRecipes: {},
+      favoriteRecipes: [],
+      token: loginResponse.token,
+    });
   });
 
   it('should return an error if the POST chef API fails', async () => {
@@ -113,6 +125,7 @@ describe('ChefService', () => {
     req.error(mockError);
 
     await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
+    expect(chefService.chef()).toBeUndefined();
   });
 
   it('should update a chef', async () => {
@@ -185,6 +198,7 @@ describe('ChefService', () => {
     req.flush(null);
 
     await expectAsync(chefPromise).toBeResolvedTo(null);
+    expect(chefService.chef()).toBeUndefined();
   });
 
   it('should return an error if the DELETE chef API fails', async () => {
@@ -197,6 +211,7 @@ describe('ChefService', () => {
     req.error(mockError);
 
     await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
+    expect(chefService.chef()).toBeUndefined();
   });
 
   it('should verify an email', async () => {
@@ -240,9 +255,19 @@ describe('ChefService', () => {
     });
     expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(credentials);
-    req.flush(mockLoginResponse());
+    const loginResponse = mockLoginResponse();
+    req.flush(loginResponse);
 
-    await expectAsync(chefPromise).toBeResolvedTo(mockLoginResponse());
+    await expectAsync(chefPromise).toBeResolvedTo(loginResponse);
+    expect(chefService.chef()).toEqual({
+      uid: loginResponse.uid,
+      email: credentials.email,
+      emailVerified: true,
+      ratings: {},
+      recentRecipes: {},
+      favoriteRecipes: [],
+      token: loginResponse.token,
+    });
   });
 
   it('should return an error if the login API fails', async () => {
@@ -259,6 +284,7 @@ describe('ChefService', () => {
     req.error(mockError);
 
     await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
+    expect(chefService.chef()).toBeUndefined();
   });
 
   it('should logout', async () => {
@@ -275,6 +301,7 @@ describe('ChefService', () => {
     req.flush(null);
 
     await expectAsync(chefPromise).toBeResolvedTo(null);
+    expect(chefService.chef()).toBeUndefined();
   });
 
   it('should return an error if the logout API fails', async () => {
@@ -287,5 +314,6 @@ describe('ChefService', () => {
     req.error(mockError);
 
     await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
+    expect(chefService.chef()).toBeUndefined();
   });
 });

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -343,4 +343,19 @@ describe('RecipeService', () => {
     const recipeCount = await recentRecipesDB.recipes.count();
     expect(recipeCount).toBe(Constants.recentRecipesDB.max);
   });
+
+  it('should toggle isFavorite for a recipe', async () => {
+    const recentRecipe = mockRecipesWithTimestamp[0];
+    await recentRecipesDB.recipes.add(recentRecipe);
+    let recipe = await recentRecipesDB.recipes.get(recentRecipe.id);
+    expect(recipe?.isFavorite).toBeFalse();
+
+    await recipeService.toggleFavoriteRecentRecipe(recentRecipe.id);
+    recipe = await recentRecipesDB.recipes.get(recentRecipe.id);
+    expect(recipe?.isFavorite).toBeTrue();
+
+    await recipeService.toggleFavoriteRecentRecipe(recentRecipe.id);
+    recipe = await recentRecipesDB.recipes.get(recentRecipe.id);
+    expect(recipe?.isFavorite).toBeFalse();
+  });
 });

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -11,7 +11,7 @@ import { firstValueFrom } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
 import { mockRecipe, mockRecipes, mockToken } from '../models/recipe.mock';
-import Recipe, { RecentRecipe, RecipeUpdate } from '../models/recipe.model';
+import { RecentRecipe, RecipeUpdate } from '../models/recipe.model';
 import { RecipeService } from './recipe.service';
 import Constants from '../constants/constants';
 import RecipeFilter from '../models/recipe-filter.model';
@@ -88,6 +88,7 @@ describe('RecipeService', () => {
 
     // When observable resolves, result should match test data
     await expectAsync(recipePromise).toBeResolvedTo(mockRecipe);
+    expect(recipeService.recipe()).toBe(mockRecipe);
   });
 
   it('should return an error if the random recipe API fails', async () => {
@@ -103,6 +104,7 @@ describe('RecipeService', () => {
     req.error(mockError);
 
     await expectAsync(chefPromise).toBeRejectedWithError(mockErrorMessage);
+    expect(recipeService.recipe()).toBeNull();
   });
 
   it('should fetch a recipe by ID', async () => {
@@ -117,6 +119,7 @@ describe('RecipeService', () => {
     req.flush(mockRecipe);
 
     await expectAsync(recipePromise).toBeResolvedTo(mockRecipe);
+    expect(recipeService.recipe()).toBe(mockRecipe);
   });
 
   it('should return an error if the recipe ID API fails', async () => {
@@ -131,6 +134,7 @@ describe('RecipeService', () => {
     req.error(mockError);
 
     await expectAsync(recipePromise).toBeRejectedWithError(mockErrorMessage);
+    expect(recipeService.recipe()).toBeNull();
   });
 
   it('should fetch recipes by filter', async () => {
@@ -282,27 +286,6 @@ describe('RecipeService', () => {
     // Check that getMockToken returns a mock token
     recipeService.getMockToken().subscribe((data) => {
       expect(data).toBe(mockToken);
-      done();
-    });
-  });
-
-  it('should set a recipe', (done) => {
-    // Check that the setRecipe method sets the recipe variable to the passed in recipe
-    recipeService.setRecipe(mockRecipe);
-
-    recipeService.onRecipeChange().subscribe((recipe: Recipe | null) => {
-      expect(recipe).toBe(mockRecipe);
-      done();
-    });
-  });
-
-  it('should reset a recipe', (done) => {
-    // Check that the resetRecipe method sets the recipe variable to null
-    recipeService.setRecipe(mockRecipe);
-    recipeService.resetRecipe();
-
-    recipeService.onRecipeChange().subscribe((recipe: Recipe | null) => {
-      expect(recipe).toBeNull();
       done();
     });
   });

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -203,4 +203,10 @@ export class RecipeService {
       }
     );
   }
+
+  async toggleFavoriteRecentRecipe(recipeId: number) {
+    await recentRecipesDB.recipes.where({ id: recipeId }).modify((recipe) => {
+      recipe.isFavorite = !recipe.isFavorite;
+    });
+  }
 }

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable, inject } from '@angular/core';
+import { Injectable, effect, inject, signal } from '@angular/core';
 import { liveQuery } from 'dexie';
-import { BehaviorSubject, catchError, Observable } from 'rxjs';
+import { catchError, Observable, tap } from 'rxjs';
 
 import Recipe, { RecipeUpdate, Token } from '../models/recipe.model';
 import { environment } from 'src/environments/environment';
@@ -20,21 +20,18 @@ export class RecipeService {
   private readonly isMocking = !environment.production && environment.mock;
 
   // Store the recipe object in the service so other components can reference it and observe changes
-  private recipe = new BehaviorSubject<Recipe | null>(null);
+  recipe = signal<Recipe | null>(null);
   // Turn on to test loading & error messages
   private mockLoading = false;
   private mockError = false;
 
-  onRecipeChange(): Observable<Recipe | null> {
-    return this.recipe.asObservable();
-  }
-
-  setRecipe(nextRecipe: Recipe) {
-    this.recipe.next(nextRecipe);
-  }
-
-  resetRecipe() {
-    this.recipe.next(null);
+  constructor() {
+    effect(() => {
+      // Log recipes fetched
+      if (this.recipe() !== null) {
+        console.log(this.recipe());
+      }
+    });
   }
 
   // API methods
@@ -60,7 +57,12 @@ export class RecipeService {
       .get<Recipe>(
         `${environment.serverBaseUrl}${Constants.recipesPath}/random`
       )
-      .pipe(catchError(handleError));
+      .pipe(
+        tap((recipe) => {
+          this.recipe.set(recipe);
+        }),
+        catchError(handleError)
+      );
   }
 
   getRecipeById(id: string): Observable<Recipe> {
@@ -70,7 +72,12 @@ export class RecipeService {
 
     return this.http
       .get<Recipe>(`${environment.serverBaseUrl}${Constants.recipesPath}/${id}`)
-      .pipe(catchError(handleError));
+      .pipe(
+        tap((recipe) => {
+          this.recipe.set(recipe);
+        }),
+        catchError(handleError)
+      );
   }
 
   updateRecipe(
@@ -103,6 +110,7 @@ export class RecipeService {
           if (this.mockError) {
             subscriber.error(Error('A mock error occurred.'));
           } else {
+            this.recipe.set(mockRecipe);
             subscriber.next(mockRecipe);
           }
 


### PR DESCRIPTION
## Logged Out

<div>
  <img src="https://github.com/user-attachments/assets/80312843-24bb-458c-bc9b-416a19567b95" alt="home-sm-logged-out" width="300">
  <img src="https://github.com/user-attachments/assets/567e4c4c-77ee-4053-903b-e44c98c9e037" alt="home-lg-logged-out" width="600">
</div>
<div>
  <img src="https://github.com/user-attachments/assets/df5f74ca-aee4-4dc5-91e9-225c1f448634" alt="recipe-sm-logged-out" width="300">
  <img src="https://github.com/user-attachments/assets/70980350-29d1-4b43-b1c4-2589e4519c4c" alt="recipe-lg-logged-out" width="600">
</div>

## Logged In

<div>
  <img src="https://github.com/user-attachments/assets/df868dc3-9562-48e3-bb3d-efc0f26369b3" alt="home-sm-logged-in" width="300">
  <img src="https://github.com/user-attachments/assets/1f64215d-b053-4162-8511-0b4ec3492755" alt="home-lg-logged-in" width="600">
</div>
<div>
  <img src="https://github.com/user-attachments/assets/adaa9cac-efd7-4709-972c-a802ee68cc9d" alt="recipe-sm-logged-in" width="300">
  <img src="https://github.com/user-attachments/assets/0d36edab-ca10-496b-914f-ba704a9be696" alt="recipe-lg-logged-in" width="600">
</div>

_The web implementation of #313, #314, & #315_

So...much...refactoring! Besides the main 3 things (views, favorites, and ratings), I couldn't resist making the following updates to all the existing components:
- Most mutable variables are replaced with states so this app can eventually go zoneless. Signals make state updates more predictable and closer to React-like behavior, like on mobile. I wish Angular did better type checking to make sure I was invoking all the signals, since I encountered multiple bugs due to my forgetting to add the parentheses. Oh, and while I'm at it, I wish it weren't so easy to mix up null and undefined for signals.
- Instead of manually unsubscribing from subscriptions, I utilized `takeUntilDestroyed()` to have Angular do it automatically. However, since it's Angular, it wasn't that simple. Outside of injection contexts, such as constructors, I have to pass a `DestroyRef` to prevent any runtime errors. This includes any methods called by the constructor, which may be called from inside an observable. Despite that, I'd still say it makes the code cleaner since I no longer need to add `ngOnDestroy` to most of the components.
- I added all cleanup logic for the observables inside a `finalize` block, such as for disabling timers or hiding loading indicators. I at first thought to add it to the `complete` block, but this doesn't run if the observable errors out.
- In both `RecipeService` and `ChefService`, I created a signal to save the current recipe and logged-in chef, respectively. Previously, I used route params to save the auth state, but this is another way I can save these variables in memory. But because of this, I would need to refetch these items on reload. I'm already doing that for the recipe, but I'll need to do that for the chef. That will happen once I implement all the accordions.

There's not much else I can say about the main updates that I didn't mention in the iOS or Android PRs. But it feels nice to finally implement all the placeholder functionality that was present on the recipe page for almost 3 years! I also finally created my first pipe after having the pipes folder sitting in my local machine for so long!

None of these features needs to be hidden. Since users can't sign in at the moment, most of these things will be disabled. Views still work without a token. The only thing is the snackbar if the user tries to submit a rating, but I'm willing to keep it while the app is in this temporary state.