### PR TITLE
Home Accordions

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,7 +13,6 @@ import { SearchComponent } from './components/search/search.component';
 import { GlossaryComponent } from './components/glossary/glossary.component';
 import { ProfileComponent } from './components/profile/profile.component';
 import { authGuard } from './guards/auth.guard';
-import { devGuard } from './guards/dev.guard';
 
 // Child routes require router-outlet, but these routes are relative to the profile component
 export const profileRoutes: Record<string, Route> = {
@@ -22,42 +21,39 @@ export const profileRoutes: Record<string, Route> = {
     title: 'Login',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.LoginComponent),
-    canActivate: [devGuard],
   },
   signUp: {
     path: 'profile/sign-up',
     title: 'Sign Up',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.SignUpComponent),
-    canActivate: [devGuard],
   },
   forgotPassword: {
     path: 'profile/forgot-password',
     title: 'Forgot Password',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.ForgotPasswordComponent),
-    canActivate: [devGuard],
   },
   verifyEmail: {
     path: 'profile/verify-email',
     title: 'Verify Email',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.VerifyEmailComponent),
-    canActivate: [devGuard, authGuard],
+    canActivate: [authGuard],
   },
   updateEmail: {
     path: 'profile/update-email',
     title: 'Update Email',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.UpdateEmailComponent),
-    canActivate: [devGuard, authGuard],
+    canActivate: [authGuard],
   },
   updatePassword: {
     path: 'profile/update-password',
     title: 'Update Password',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.UpdatePasswordComponent),
-    canActivate: [devGuard, authGuard],
+    canActivate: [authGuard],
   },
   changePassword: {
     path: '.well-known/change-password',
@@ -68,7 +64,7 @@ export const profileRoutes: Record<string, Route> = {
     title: 'Delete Account',
     loadComponent: () =>
       import('./components/profile').then((mod) => mod.DeleteAccountComponent),
-    canActivate: [devGuard, authGuard],
+    canActivate: [authGuard],
   },
 };
 
@@ -94,7 +90,6 @@ export const routes: Record<string, Route> = {
     path: 'profile',
     title: 'Profile',
     component: ProfileComponent,
-    canActivate: [devGuard],
   },
   ...profileRoutes,
   // The default route should be listed between the static routes and wildcard routes

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -18,7 +18,10 @@
 
 <!-- Multiple accordions can be expanded -->
 <mat-accordion multi class="home-accordion">
-  <mat-expansion-panel (opened)="onExpandFavorites()">
+  <mat-expansion-panel
+    class="favorites-accordion"
+    (opened)="onExpandFavorites()"
+  >
     <mat-expansion-panel-header>
       <mat-panel-title>💖 Favorites</mat-panel-title>
     </mat-expansion-panel-header>
@@ -32,7 +35,7 @@
     } } @else if (favoriteRecipes().length === 0) {
     <p>No recipes found</p>
     } @else {
-    <ul class="recents-list">
+    <ul class="recipe-card-list">
       @for (recipe of favoriteRecipes(); track recipe?.id) {
       <li>
         @if (recipe !== undefined) {
@@ -46,28 +49,28 @@
     }
   </mat-expansion-panel>
 
-  <mat-expansion-panel (opened)="onExpandRecents()">
+  <mat-expansion-panel class="recents-accordion" (opened)="onExpandRecents()">
     <mat-expansion-panel-header>
       <mat-panel-title>⌚ Recently Viewed</mat-panel-title>
     </mat-expansion-panel-header>
 
     @if (!isLoggedIn()) {
     <!-- Show what's stored locally while the chef isn't signed in -->
-    @if (recentRecipes().length === 0) {
+    @if (recentRecipesLocal().length === 0) {
     <p>No recipes found</p>
     } @else {
-    <ul class="recents-list">
-      @for (recipe of recentRecipes(); track recipe.id) {
+    <ul class="recipe-card-list">
+      @for (recipe of recentRecipesLocal(); track recipe.id) {
       <li>
         <app-recipe-card [recipe]="recipe" />
       </li>
       }
     </ul>
-    } } @else if (recentRecipes2().length === 0) {
+    } } @else if (recentRecipesRemote().length === 0) {
     <p>No recipes found</p>
     } @else {
-    <ul class="recents-list">
-      @for (recipe of recentRecipes2(); track recipe?.id) {
+    <ul class="recipe-card-list">
+      @for (recipe of recentRecipesRemote(); track recipe?.id) {
       <li>
         @if (recipe !== undefined) {
         <app-recipe-card [recipe]="recipe" />
@@ -80,7 +83,7 @@
     }
   </mat-expansion-panel>
 
-  <mat-expansion-panel (opened)="onExpandRatings()">
+  <mat-expansion-panel class="ratings-accordion" (opened)="onExpandRatings()">
     <mat-expansion-panel-header>
       <mat-panel-title>⭐ Ratings</mat-panel-title>
     </mat-expansion-panel-header>
@@ -92,7 +95,7 @@
     } } @else if (ratedRecipes().length === 0) {
     <p>No recipes found</p>
     } @else {
-    <ul class="recents-list">
+    <ul class="recipe-card-list">
       @for (recipe of ratedRecipes(); track recipe?.id) {
       <li>
         @if (recipe !== undefined) {

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -17,20 +17,45 @@
 }
 
 <!-- Multiple accordions can be expanded -->
-<!-- <mat-accordion multi>
-  <mat-expansion-panel>
+<mat-accordion multi class="home-accordion">
+  <mat-expansion-panel (opened)="onExpandFavorites()">
     <mat-expansion-panel-header>
       <mat-panel-title>💖 Favorites</mat-panel-title>
     </mat-expansion-panel-header>
 
+    @if (!isLoggedIn()) { @if (isLoading()) {
+    <!-- Show the recipe cards loading while waiting for both the auth state & recipes -->
     <app-recipe-card-loader />
+    } @else {
+    <!-- Encourage the user to sign in to see these recipes -->
+    <p>Sign in to view your saved recipes</p>
+    } } @else if (favoriteRecipes().length === 0) {
+    <p>No recipes found</p>
+    } @else {
+    <ul class="recents-list">
+      @for (recipe of favoriteRecipes(); track recipe?.id) {
+      <li>
+        @if (recipe !== undefined) {
+        <app-recipe-card [recipe]="recipe" />
+        } @else {
+        <app-recipe-card-loader />
+        }
+      </li>
+      }
+    </ul>
+    }
   </mat-expansion-panel>
 
-  <mat-expansion-panel>
+  <mat-expansion-panel (opened)="onExpandRecents()">
     <mat-expansion-panel-header>
       <mat-panel-title>⌚ Recently Viewed</mat-panel-title>
     </mat-expansion-panel-header>
 
+    @if (!isLoggedIn()) {
+    <!-- Show what's stored locally while the chef isn't signed in -->
+    @if (recentRecipes().length === 0) {
+    <p>No recipes found</p>
+    } @else {
     <ul class="recents-list">
       @for (recipe of recentRecipes(); track recipe.id) {
       <li>
@@ -38,27 +63,46 @@
       </li>
       }
     </ul>
+    } } @else if (recentRecipes2().length === 0) {
+    <p>No recipes found</p>
+    } @else {
+    <ul class="recents-list">
+      @for (recipe of recentRecipes2(); track recipe?.id) {
+      <li>
+        @if (recipe !== undefined) {
+        <app-recipe-card [recipe]="recipe" />
+        } @else {
+        <app-recipe-card-loader />
+        }
+      </li>
+      }
+    </ul>
+    }
   </mat-expansion-panel>
 
-  <mat-expansion-panel>
+  <mat-expansion-panel (opened)="onExpandRatings()">
     <mat-expansion-panel-header>
       <mat-panel-title>⭐ Ratings</mat-panel-title>
     </mat-expansion-panel-header>
 
-    <app-recipe-card [recipe]="recentRecipes()[0]" />
-  </mat-expansion-panel>
-</mat-accordion> -->
-
-@if (recentRecipes().length > 0) {
-<section class="recents-section">
-  <h1 class="recents-title">Recently Viewed</h1>
-  <mat-divider />
-  <ul class="recents-list">
-    @for (recipe of recentRecipes(); track recipe.id) {
-    <li>
-      <app-recipe-card [recipe]="recipe" />
-    </li>
+    @if (!isLoggedIn()) { @if (isLoading()) {
+    <app-recipe-card-loader />
+    } @else {
+    <p>Sign in to view your saved recipes</p>
+    } } @else if (ratedRecipes().length === 0) {
+    <p>No recipes found</p>
+    } @else {
+    <ul class="recents-list">
+      @for (recipe of ratedRecipes(); track recipe?.id) {
+      <li>
+        @if (recipe !== undefined) {
+        <app-recipe-card [recipe]="recipe" />
+        } @else {
+        <app-recipe-card-loader />
+        }
+      </li>
+      }
+    </ul>
     }
-  </ul>
-</section>
-}
+  </mat-expansion-panel>
+</mat-accordion>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -5,13 +5,13 @@
     color="accent"
     class="find-recipe-button"
     (click)="getRandomRecipe()"
-    [disabled]="isLoading()"
+    [disabled]="isLoadingRecipe()"
   >
     Find Me a Recipe!
   </button>
 </div>
 
-@if (isLoading()) {
+@if (isLoadingRecipe()) {
 <mat-spinner diameter="50" class="progress-spinner" />
 <p class="loading-message">{{ loadingMessage() }}</p>
 }
@@ -34,7 +34,7 @@
     </li>
     }
   </ul>
-  } } @else if (isLoading()) {
+  } } @else if (isLoadingChef()) {
   <!-- Show the recipe cards loading while waiting for both the auth state & recipes -->
   <app-recipe-card-loader />
   } @else {

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -16,6 +16,47 @@
 <p class="loading-message">{{ loadingMessage() }}</p>
 }
 
+<!-- Reusable container for the accordions -->
+<ng-template
+  #recipeCards
+  let-recipes="recipes"
+  let-showWhenOffline="showWhenOffline"
+>
+  @if (!isLoggedIn()) { @if (showWhenOffline) {
+  <!-- Show what's stored locally while the chef isn't signed in -->
+  @if (recentRecipesLocal().length === 0) {
+  <p>No recipes found</p>
+  } @else {
+  <ul class="recipe-card-list">
+    @for (recipe of recentRecipesLocal(); track recipe.id) {
+    <li>
+      <app-recipe-card [recipe]="recipe" />
+    </li>
+    }
+  </ul>
+  } } @else if (isLoading()) {
+  <!-- Show the recipe cards loading while waiting for both the auth state & recipes -->
+  <app-recipe-card-loader />
+  } @else {
+  <!-- Encourage the user to sign in to see these recipes -->
+  <p>Sign in to view your saved recipes</p>
+  } } @else if (recipes().length === 0) {
+  <p>No recipes found</p>
+  } @else {
+  <ul class="recipe-card-list">
+    @for (recipe of recipes(); track recipe?.id) {
+    <li>
+      @if (recipe !== undefined) {
+      <app-recipe-card [recipe]="recipe" />
+      } @else {
+      <app-recipe-card-loader />
+      }
+    </li>
+    }
+  </ul>
+  }
+</ng-template>
+
 <!-- Multiple accordions can be expanded -->
 <mat-accordion multi class="home-accordion">
   <mat-expansion-panel
@@ -26,27 +67,9 @@
       <mat-panel-title>💖 Favorites</mat-panel-title>
     </mat-expansion-panel-header>
 
-    @if (!isLoggedIn()) { @if (isLoading()) {
-    <!-- Show the recipe cards loading while waiting for both the auth state & recipes -->
-    <app-recipe-card-loader />
-    } @else {
-    <!-- Encourage the user to sign in to see these recipes -->
-    <p>Sign in to view your saved recipes</p>
-    } } @else if (favoriteRecipes().length === 0) {
-    <p>No recipes found</p>
-    } @else {
-    <ul class="recipe-card-list">
-      @for (recipe of favoriteRecipes(); track recipe?.id) {
-      <li>
-        @if (recipe !== undefined) {
-        <app-recipe-card [recipe]="recipe" />
-        } @else {
-        <app-recipe-card-loader />
-        }
-      </li>
-      }
-    </ul>
-    }
+    <ng-container
+      *ngTemplateOutlet="recipeCards; context: recipeCardContext.favorites"
+    />
   </mat-expansion-panel>
 
   <mat-expansion-panel class="recents-accordion" (opened)="onExpandRecents()">
@@ -54,33 +77,9 @@
       <mat-panel-title>⌚ Recently Viewed</mat-panel-title>
     </mat-expansion-panel-header>
 
-    @if (!isLoggedIn()) {
-    <!-- Show what's stored locally while the chef isn't signed in -->
-    @if (recentRecipesLocal().length === 0) {
-    <p>No recipes found</p>
-    } @else {
-    <ul class="recipe-card-list">
-      @for (recipe of recentRecipesLocal(); track recipe.id) {
-      <li>
-        <app-recipe-card [recipe]="recipe" />
-      </li>
-      }
-    </ul>
-    } } @else if (recentRecipesRemote().length === 0) {
-    <p>No recipes found</p>
-    } @else {
-    <ul class="recipe-card-list">
-      @for (recipe of recentRecipesRemote(); track recipe?.id) {
-      <li>
-        @if (recipe !== undefined) {
-        <app-recipe-card [recipe]="recipe" />
-        } @else {
-        <app-recipe-card-loader />
-        }
-      </li>
-      }
-    </ul>
-    }
+    <ng-container
+      *ngTemplateOutlet="recipeCards; context: recipeCardContext.recents"
+    />
   </mat-expansion-panel>
 
   <mat-expansion-panel class="ratings-accordion" (opened)="onExpandRatings()">
@@ -88,24 +87,8 @@
       <mat-panel-title>⭐ Ratings</mat-panel-title>
     </mat-expansion-panel-header>
 
-    @if (!isLoggedIn()) { @if (isLoading()) {
-    <app-recipe-card-loader />
-    } @else {
-    <p>Sign in to view your saved recipes</p>
-    } } @else if (ratedRecipes().length === 0) {
-    <p>No recipes found</p>
-    } @else {
-    <ul class="recipe-card-list">
-      @for (recipe of ratedRecipes(); track recipe?.id) {
-      <li>
-        @if (recipe !== undefined) {
-        <app-recipe-card [recipe]="recipe" />
-        } @else {
-        <app-recipe-card-loader />
-        }
-      </li>
-      }
-    </ul>
-    }
+    <ng-container
+      *ngTemplateOutlet="recipeCards; context: recipeCardContext.ratings"
+    />
   </mat-expansion-panel>
 </mat-accordion>

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -18,10 +18,8 @@
   font-size: 1.2em;
 }
 
-.recents-section {
-  .recents-title {
-    margin: 24px 16px 8px;
-  }
+.home-accordion {
+  margin: 24px 16px 8px;
 
   .recents-list {
     list-style-type: none;

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -21,7 +21,7 @@
 .home-accordion {
   margin: 24px 16px 8px;
 
-  .recents-list {
+  .recipe-card-list {
     list-style-type: none;
     padding-left: 0;
     margin: 16px;

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -38,6 +38,8 @@ describe('HomeComponent', () => {
   };
 
   beforeEach(async () => {
+    spyOn(ChefService.prototype, 'getChef').and.returnValue(of(mockChef));
+
     // Import all the necessary modules and components to test the app component
     await TestBed.configureTestingModule({
       imports: [RouterModule.forRoot([])],
@@ -81,7 +83,7 @@ describe('HomeComponent', () => {
     ).toBeDefined();
 
     // The spinner should be hidden
-    expect(homeComponent.isLoading()).toBeFalse();
+    expect(homeComponent.isLoadingRecipe()).toBeFalse();
     expect(rootElement.querySelector('.progress-spinner')).toBeNull();
 
     // All the accordions should be present
@@ -117,7 +119,7 @@ describe('HomeComponent', () => {
 
   it('should show a spinner while loading', () => {
     // Check that the material spinner shows when isLoading is true
-    homeComponent.isLoading.set(true);
+    homeComponent.isLoadingRecipe.set(true);
     fixture.detectChanges();
 
     expect(rootElement.querySelector('.progress-spinner')).not.toBeNull();

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,7 +1,9 @@
+import { CommonModule } from '@angular/common';
 import {
   Component,
   DestroyRef,
   OnInit,
+  WritableSignal,
   computed,
   inject,
   signal,
@@ -25,6 +27,7 @@ import { ChefService } from 'src/app/services/chef.service';
 @Component({
   selector: 'app-home',
   imports: [
+    CommonModule,
     MatButtonModule,
     MatExpansionModule,
     MatProgressSpinnerModule,
@@ -48,11 +51,21 @@ export class HomeComponent implements OnInit {
   isLoggedIn = computed(() => this.chefService.chef() !== undefined);
 
   private didExpandFavorites = signal(false);
-  favoriteRecipes = signal<(Recipe | undefined)[]>([]);
+  private favoriteRecipes = signal<(Recipe | undefined)[]>([]);
   private didExpandRecents = signal(false);
-  recentRecipesRemote = signal<(Recipe | undefined)[]>([]);
+  private recentRecipesRemote = signal<(Recipe | undefined)[]>([]);
   private didExpandRatings = signal(false);
-  ratedRecipes = signal<(Recipe | undefined)[]>([]);
+  private ratedRecipes = signal<(Recipe | undefined)[]>([]);
+  recipeCardContext: {
+    [key: string]: {
+      recipes: WritableSignal<(Recipe | undefined)[]>;
+      showWhenOffline: boolean;
+    };
+  } = {
+    favorites: { recipes: this.favoriteRecipes, showWhenOffline: false },
+    recents: { recipes: this.recentRecipesRemote, showWhenOffline: true },
+    ratings: { recipes: this.ratedRecipes, showWhenOffline: false },
+  };
 
   ngOnInit(): void {
     // Get all the recent recipes from IndexedDB

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -44,7 +44,8 @@ export class HomeComponent implements OnInit {
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
-  isLoading = signal(false);
+  isLoadingRecipe = signal(false);
+  isLoadingChef = signal(false);
   private readonly defaultLoadingMessage = '';
   loadingMessage = signal(this.defaultLoadingMessage);
   recentRecipesLocal = signal<Recipe[]>([]);
@@ -79,14 +80,22 @@ export class HomeComponent implements OnInit {
     });
 
     if (!this.isLoggedIn()) {
-      // subscribe is required to call the API without getting the result
-      this.chefService.getChef().subscribe();
+      this.isLoadingChef.set(true);
+      this.chefService
+        .getChef()
+        .pipe(
+          finalize(() => {
+            this.isLoadingChef.set(false);
+          })
+        )
+        // subscribe is required to call the API without getting the result
+        .subscribe();
     }
   }
 
   getRandomRecipe() {
     // Show the progress spinner while the recipe is loading
-    this.isLoading.set(true);
+    this.isLoadingRecipe.set(true);
     const timer = this.showLoadingMessages();
 
     // Show a random, low-effort recipe
@@ -97,7 +106,7 @@ export class HomeComponent implements OnInit {
         // destroyRef is required if called outside a constructor
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
-          this.isLoading.set(false);
+          this.isLoadingRecipe.set(false);
           clearInterval(timer);
         })
       )

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,12 +1,18 @@
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { finalize } from 'rxjs';
+import { finalize, materialize, zip } from 'rxjs';
 
 import Constants from 'src/app/constants/constants';
 import { getRandomElement } from 'src/app/helpers/array';
@@ -14,12 +20,12 @@ import Recipe from 'src/app/models/recipe.model';
 import { RecipeService } from 'src/app/services/recipe.service';
 import { RecipeCardComponent } from '../utils/recipe-card/recipe-card.component';
 import { RecipeCardLoaderComponent } from '../utils/recipe-card-loader/recipe-card-loader.component';
+import { ChefService } from 'src/app/services/chef.service';
 
 @Component({
   selector: 'app-home',
   imports: [
     MatButtonModule,
-    MatDividerModule,
     MatExpansionModule,
     MatProgressSpinnerModule,
     RecipeCardComponent,
@@ -30,6 +36,7 @@ import { RecipeCardLoaderComponent } from '../utils/recipe-card-loader/recipe-ca
 })
 export class HomeComponent implements OnInit {
   private recipeService = inject(RecipeService);
+  private chefService = inject(ChefService);
   private snackBar = inject(MatSnackBar);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
@@ -38,6 +45,14 @@ export class HomeComponent implements OnInit {
   private readonly defaultLoadingMessage = '';
   loadingMessage = signal(this.defaultLoadingMessage);
   recentRecipes = signal<Recipe[]>([]);
+  isLoggedIn = computed(() => this.chefService.chef() !== undefined);
+
+  private didExpandFavorites = signal(false);
+  favoriteRecipes = signal<(Recipe | undefined)[]>([]);
+  private didExpandRecents = signal(false);
+  recentRecipes2 = signal<(Recipe | undefined)[]>([]);
+  private didExpandRatings = signal(false);
+  ratedRecipes = signal<(Recipe | undefined)[]>([]);
 
   ngOnInit(): void {
     // Get all the recent recipes from IndexedDB
@@ -49,6 +64,12 @@ export class HomeComponent implements OnInit {
         this.snackBar.open(error.message, 'Dismiss');
       },
     });
+
+    if (!this.isLoggedIn()) {
+      const token = localStorage.getItem(Constants.LocalStorage.token);
+      if (token === null) return;
+      this.chefService.getChef(token).subscribe();
+    }
   }
 
   getRandomRecipe() {
@@ -86,5 +107,142 @@ export class HomeComponent implements OnInit {
     return setInterval(() => {
       this.loadingMessage.set(getRandomElement(Constants.loadingMessages));
     }, 3000);
+  }
+
+  onExpandFavorites() {
+    // Only fetch the recipes once per load
+    if (this.isLoggedIn() && !this.didExpandFavorites()) {
+      this.didExpandFavorites.set(true);
+
+      const chef = this.chefService.chef();
+      const recipeIds = chef?.favoriteRecipes ?? [];
+      this.favoriteRecipes.set(recipeIds.map(() => undefined)); // undefined == loading
+
+      // Fetch all recipes in parallel
+      // forkJoin == Promise.all, zip+materialize == Promise.allSettled
+      zip(
+        recipeIds.map((recipeId) =>
+          this.recipeService.getRecipeById(recipeId).pipe(materialize())
+        )
+      )
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (notifications) => {
+            const newFavoriteRecipes = this.favoriteRecipes();
+
+            for (const [
+              index,
+              { kind, value, error },
+            ] of notifications.entries()) {
+              // N == next, E == error, C == complete
+              if (kind === 'N') {
+                newFavoriteRecipes[index] = value;
+              } else if (kind === 'E') {
+                console.warn(
+                  `Failed to get recipe ${recipeIds[index]}:`,
+                  error.message
+                );
+              }
+            }
+
+            // Remove all recipes that failed to load
+            this.favoriteRecipes.set(
+              newFavoriteRecipes.filter((recipe) => recipe !== undefined)
+            );
+          },
+          error: (error) => {
+            console.error('Failed to get all favorite recipes:', error.message);
+          },
+        });
+    }
+  }
+
+  onExpandRecents() {
+    if (this.isLoggedIn() && !this.didExpandRecents()) {
+      this.didExpandRecents.set(true);
+
+      const chef = this.chefService.chef();
+      // Sort the recipe IDs by most recent timestamp
+      const recipeIds = Object.entries(chef?.recentRecipes ?? {})
+        .toSorted(([, time1], [, time2]) => time2.localeCompare(time1))
+        .map(([recipeId]) => recipeId);
+      this.recentRecipes2.set(recipeIds.map(() => undefined));
+
+      zip(
+        recipeIds.map((recipeId) =>
+          this.recipeService.getRecipeById(recipeId).pipe(materialize())
+        )
+      )
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (notifications) => {
+            const newRecentRecipes = this.recentRecipes2();
+
+            for (const [
+              index,
+              { kind, value, error },
+            ] of notifications.entries()) {
+              if (kind === 'N') {
+                newRecentRecipes[index] = value;
+              } else if (kind === 'E') {
+                console.warn(
+                  `Failed to get recipe ${recipeIds[index]}:`,
+                  error.message
+                );
+              }
+            }
+
+            this.recentRecipes2.set(
+              newRecentRecipes.filter((recipe) => recipe !== undefined)
+            );
+          },
+          error: (error) => {
+            console.error('Failed to get all recent recipes:', error.message);
+          },
+        });
+    }
+  }
+
+  onExpandRatings() {
+    if (this.isLoggedIn() && !this.didExpandRatings()) {
+      this.didExpandRatings.set(true);
+
+      const chef = this.chefService.chef();
+      const recipeIds = Object.keys(chef?.ratings ?? {});
+      this.ratedRecipes.set(recipeIds.map(() => undefined));
+
+      zip(
+        recipeIds.map((recipeId) =>
+          this.recipeService.getRecipeById(recipeId).pipe(materialize())
+        )
+      )
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (notifications) => {
+            const newRatedRecipes = this.ratedRecipes();
+
+            for (const [
+              index,
+              { kind, value, error },
+            ] of notifications.entries()) {
+              if (kind === 'N') {
+                newRatedRecipes[index] = value;
+              } else if (kind === 'E') {
+                console.warn(
+                  `Failed to get recipe ${recipeIds[index]}:`,
+                  error.message
+                );
+              }
+            }
+
+            this.ratedRecipes.set(
+              newRatedRecipes.filter((recipe) => recipe !== undefined)
+            );
+          },
+          error: (error) => {
+            console.error('Failed to get all rated recipes:', error.message);
+          },
+        });
+    }
   }
 }

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -79,9 +79,8 @@ export class HomeComponent implements OnInit {
     });
 
     if (!this.isLoggedIn()) {
-      const token = localStorage.getItem(Constants.LocalStorage.token);
-      if (token === null) return;
-      this.chefService.getChef(token).subscribe();
+      // subscribe is required to call the API without getting the result
+      this.chefService.getChef().subscribe();
     }
   }
 

--- a/src/app/components/navbar/navbar.component.spec.ts
+++ b/src/app/components/navbar/navbar.component.spec.ts
@@ -154,11 +154,9 @@ describe('NavbarComponent', () => {
 
     favoriteButton?.click();
     fixture.detectChanges();
-    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(
-      mockRecipe.id,
-      { isFavorite: true },
-      mockChef.token
-    );
+    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(mockRecipe.id, {
+      isFavorite: true,
+    });
     expect(navbarComponent.chef()?.favoriteRecipes).toContain(
       mockRecipe.id.toString()
     );
@@ -168,11 +166,9 @@ describe('NavbarComponent', () => {
 
     favoriteButton?.click();
     fixture.detectChanges();
-    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(
-      mockRecipe.id,
-      { isFavorite: false },
-      mockChef.token
-    );
+    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(mockRecipe.id, {
+      isFavorite: false,
+    });
     expect(navbarComponent.chef()?.favoriteRecipes).not.toContain(
       mockRecipe.id.toString()
     );

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -14,7 +14,6 @@ import { RecipeComponent } from '../recipe/recipe.component';
 import { routes } from 'src/app/app-routing.module';
 import { ChefService } from 'src/app/services/chef.service';
 import { RecipeUpdate } from 'src/app/models/recipe.model';
-import Constants from 'src/app/constants/constants';
 import { RecipeService } from 'src/app/services/recipe.service';
 
 @Component({
@@ -80,11 +79,9 @@ export class NavbarComponent {
     const recipeUpdate: RecipeUpdate = {
       isFavorite: !this.isFavorite(),
     };
-    const token =
-      localStorage.getItem(Constants.LocalStorage.token) ?? undefined;
 
-    this.recipeService.updateRecipe(recipeId, recipeUpdate, token).subscribe({
-      next: ({ token }) => {
+    this.recipeService.updateRecipe(recipeId, recipeUpdate).subscribe({
+      next: () => {
         const newFavoriteRecipes = this.isFavorite()
           ? this.chef()?.favoriteRecipes?.filter(
               (id) => id !== recipeId.toString()
@@ -106,10 +103,6 @@ export class NavbarComponent {
               error.message
             );
           });
-
-        if (token !== undefined) {
-          localStorage.setItem(Constants.LocalStorage.token, token);
-        }
       },
       error: (error) => {
         this.snackBar.open(error.message, 'Dismiss');

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -12,7 +12,6 @@ import { RouterModule } from '@angular/router';
 
 import { RecipeComponent } from '../recipe/recipe.component';
 import { routes } from 'src/app/app-routing.module';
-import { environment } from 'src/environments/environment';
 import { ChefService } from 'src/app/services/chef.service';
 import { RecipeUpdate } from 'src/app/models/recipe.model';
 import Constants from 'src/app/constants/constants';
@@ -41,9 +40,12 @@ export class NavbarComponent {
   // Detect breakpoint changes so the template can respond
   isSmallScreen = signal(this.breakpointObserver.isMatched(Breakpoints.XSmall));
   // Navigation links to show in the sidenav
-  readonly navItems = environment.production
-    ? [routes.home, routes.search, routes.glossary]
-    : [routes.home, routes.search, routes.glossary, routes.profile];
+  readonly navItems = [
+    routes.home,
+    routes.search,
+    routes.glossary,
+    routes.profile,
+  ];
 
   recipe = this.recipeService.recipe;
   chef = this.chefService.chef;

--- a/src/app/components/profile/delete-account/delete-account.component.spec.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.spec.ts
@@ -121,7 +121,7 @@ describe('DeleteAccountComponent', () => {
     submitButton?.click();
     fixture.detectChanges();
 
-    expect(mockChefService.deleteChef).toHaveBeenCalledWith(mockChef.token);
+    expect(mockChefService.deleteChef).toHaveBeenCalledWith();
     expect(navigateSpy).toHaveBeenCalledWith([routes.profile.path]);
   });
 });

--- a/src/app/components/profile/delete-account/delete-account.component.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.ts
@@ -22,7 +22,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { finalize } from 'rxjs';
 
-import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
 import { routes } from 'src/app/app-routing.module';
 
@@ -87,15 +86,9 @@ export class DeleteAccountComponent implements OnInit {
 
   deleteAccount() {
     this.isLoading.set(true);
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token === null) {
-      this.isLoading.set(false);
-      this.snackBar.open(Constants.noTokenFound, 'Dismiss');
-      return;
-    }
 
     this.chefService
-      .deleteChef(token)
+      .deleteChef()
       .pipe(
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
@@ -104,7 +97,6 @@ export class DeleteAccountComponent implements OnInit {
       )
       .subscribe({
         next: () => {
-          localStorage.removeItem(Constants.LocalStorage.token);
           this.snackBar.open('Your account has been deleted.', 'Dismiss');
           this.router.navigate([routes.profile.path]);
         },

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -118,9 +118,7 @@ describe('LoginComponent', () => {
       email: mockEmail,
       password: mockPassword,
     });
-    expect(mockChefService.verifyEmail).toHaveBeenCalledWith(
-      mockLoginResponse(false).token
-    );
+    expect(mockChefService.verifyEmail).toHaveBeenCalledWith();
     expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path], {
       state: { email: mockEmail },
     });

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -18,7 +18,6 @@ import { finalize } from 'rxjs';
 import { ChefService } from 'src/app/services/chef.service';
 import { LoginCredentials } from 'src/app/models/profile.model';
 import { profileRoutes, routes } from 'src/app/app-routing.module';
-import Constants from 'src/app/constants/constants';
 
 @Component({
   selector: 'app-login',
@@ -79,13 +78,11 @@ export class LoginComponent {
         })
       )
       .subscribe({
-        next: ({ token, emailVerified }) => {
-          localStorage.setItem(Constants.LocalStorage.token, token);
-
+        next: ({ emailVerified }) => {
           // Check if the user signed up, but didn't verify their email yet
           if (!emailVerified) {
             // Don't update the chef's verified status until they click the redirect link
-            this.chefService.verifyEmail(token).subscribe();
+            this.chefService.verifyEmail().subscribe();
             this.router.navigate([profileRoutes.verifyEmail.path], {
               state: { email: username },
             });

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -60,20 +60,13 @@ export class ProfileComponent implements OnInit {
       // If redirected from the login page, the chef's recipe stats still need to be fetched
       this.authState.set(AuthState.Authenticated);
     } else {
-      this.chefService.getChef(token).subscribe({
-        next: (chefResponse) => {
-          localStorage.setItem(
-            Constants.LocalStorage.token,
-            chefResponse.token
-          );
+      this.chefService.getChef().subscribe({
+        next: ({ emailVerified }) => {
           this.authState.set(
-            chefResponse.emailVerified
-              ? AuthState.Authenticated
-              : AuthState.Unauthenticated
+            emailVerified ? AuthState.Authenticated : AuthState.Unauthenticated
           );
         },
         error: (error) => {
-          localStorage.removeItem(Constants.LocalStorage.token);
           this.authState.set(AuthState.Unauthenticated);
           this.snackBar.open(error.message, 'Dismiss');
         },
@@ -101,13 +94,7 @@ export class ProfileComponent implements OnInit {
   }
 
   logout() {
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token !== null) {
-      // subscribe is required to call the API without getting the result
-      this.chefService.logout(token).subscribe();
-    }
-    // Assume the user should be signed out since there's no auth token
-    localStorage.removeItem(Constants.LocalStorage.token);
+    this.chefService.logout().subscribe();
     this.authState.set(AuthState.Unauthenticated);
   }
 

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -7,7 +7,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
-import { AuthState, Chef, ProfileAction } from 'src/app/models/profile.model';
+import { AuthState, ProfileAction } from 'src/app/models/profile.model';
 import { profileRoutes } from 'src/app/app-routing.module';
 import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
@@ -33,7 +33,7 @@ export class ProfileComponent implements OnInit {
 
   AuthState = AuthState;
   authState = signal(AuthState.Loading);
-  chef = signal<Chef | undefined>(undefined);
+  chef = this.chefService.chef;
   profileRoutes = profileRoutes;
 
   readonly totalRecipesFavorited = computed(
@@ -52,10 +52,16 @@ export class ProfileComponent implements OnInit {
 
     if (token === null) {
       this.authState.set(AuthState.Unauthenticated);
+    } else if (
+      this.totalRecipesFavorited() > 0 ||
+      this.totalRecipesViewed() > 0 ||
+      this.totalRecipesRated() > 0
+    ) {
+      // If redirected from the login page, the chef's recipe stats still need to be fetched
+      this.authState.set(AuthState.Authenticated);
     } else {
       this.chefService.getChef(token).subscribe({
         next: (chefResponse) => {
-          this.chef.set(chefResponse);
           localStorage.setItem(
             Constants.LocalStorage.token,
             chefResponse.token

--- a/src/app/components/profile/sign-up/sign-up.component.spec.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.spec.ts
@@ -192,9 +192,7 @@ describe('SignUpComponent', () => {
       email: mockEmail,
       password: mockPassword,
     });
-    expect(mockChefService.verifyEmail).toHaveBeenCalledWith(
-      mockLoginResponse(false).token
-    );
+    expect(mockChefService.verifyEmail).toHaveBeenCalledWith();
     expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.verifyEmail.path], {
       state: { email: mockEmail },
     });

--- a/src/app/components/profile/sign-up/sign-up.component.ts
+++ b/src/app/components/profile/sign-up/sign-up.component.ts
@@ -129,12 +129,10 @@ export class SignUpComponent {
         })
       )
       .subscribe({
-        next: ({ token, emailVerified }) => {
-          localStorage.setItem(Constants.LocalStorage.token, token);
-
+        next: ({ emailVerified }) => {
           if (!emailVerified) {
             // Should always be true
-            this.chefService.verifyEmail(token).subscribe();
+            this.chefService.verifyEmail().subscribe();
             this.router.navigate([profileRoutes.verifyEmail.path], {
               state: { email },
             });

--- a/src/app/components/profile/update-email/update-email.component.spec.ts
+++ b/src/app/components/profile/update-email/update-email.component.spec.ts
@@ -105,13 +105,10 @@ describe('UpdateEmailComponent', () => {
     submitButton?.click();
     fixture.detectChanges();
 
-    expect(mockChefService.updateChef).toHaveBeenCalledWith(
-      {
-        type: ChefUpdateType.Email,
-        email: mockEmail,
-      },
-      mockChef.token
-    );
+    expect(mockChefService.updateChef).toHaveBeenCalledWith({
+      type: ChefUpdateType.Email,
+      email: mockEmail,
+    });
     expect(rootElement.textContent).toContain(
       `We sent an email to ${mockEmail}`
     );

--- a/src/app/components/profile/update-email/update-email.component.ts
+++ b/src/app/components/profile/update-email/update-email.component.ts
@@ -13,7 +13,6 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { finalize } from 'rxjs';
 
-import Constants from 'src/app/constants/constants';
 import { ChefUpdate, ChefUpdateType } from 'src/app/models/profile.model';
 import { ChefService } from 'src/app/services/chef.service';
 
@@ -62,15 +61,9 @@ export class UpdateEmailComponent {
       type: ChefUpdateType.Email,
       email: email ?? '',
     };
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token === null) {
-      this.isLoading.set(false);
-      this.snackBar.open(Constants.noTokenFound, 'Dismiss');
-      return;
-    }
 
     this.chefService
-      .updateChef(fields, token)
+      .updateChef(fields)
       .pipe(
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
@@ -78,12 +71,8 @@ export class UpdateEmailComponent {
         })
       )
       .subscribe({
-        next: ({ token }) => {
+        next: () => {
           this.emailSent.set(true);
-
-          if (token !== undefined) {
-            localStorage.setItem(Constants.LocalStorage.token, token);
-          }
         },
         error: (error) => {
           this.snackBar.open(error.message, 'Dismiss');

--- a/src/app/components/profile/update-password/update-password.component.spec.ts
+++ b/src/app/components/profile/update-password/update-password.component.spec.ts
@@ -165,14 +165,11 @@ describe('UpdatePasswordComponent', () => {
     submitButton?.click();
     fixture.detectChanges();
 
-    expect(mockChefService.updateChef).toHaveBeenCalledWith(
-      {
-        type: ChefUpdateType.Password,
-        email: mockChef.email,
-        password: mockPassword,
-      },
-      mockChef.token
-    );
+    expect(mockChefService.updateChef).toHaveBeenCalledWith({
+      type: ChefUpdateType.Password,
+      email: mockChef.email,
+      password: mockPassword,
+    });
     expect(navigateSpy).toHaveBeenCalledWith([profileRoutes.login.path]);
   });
 });

--- a/src/app/components/profile/update-password/update-password.component.ts
+++ b/src/app/components/profile/update-password/update-password.component.ts
@@ -116,15 +116,9 @@ export class UpdatePasswordComponent implements OnInit {
       email: this.chefEmail(),
       password: password ?? '',
     };
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token === null) {
-      this.isLoading.set(false);
-      this.snackBar.open(Constants.noTokenFound, 'Dismiss');
-      return;
-    }
 
     this.chefService
-      .updateChef(fields, token)
+      .updateChef(fields)
       .pipe(
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
@@ -133,8 +127,6 @@ export class UpdatePasswordComponent implements OnInit {
       )
       .subscribe({
         next: () => {
-          // The token will be revoked, so sign out the user
-          localStorage.removeItem(Constants.LocalStorage.token);
           this.snackBar.open(
             'Password updated successfully! Please sign in again.',
             'Dismiss'

--- a/src/app/components/profile/verify-email/verify-email.component.spec.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.spec.ts
@@ -68,7 +68,7 @@ describe('VerifyEmailComponent', () => {
       ?.querySelector<HTMLButtonElement>('button');
     resendButton?.click();
 
-    expect(mockChefService.verifyEmail).toHaveBeenCalledWith(mockChef.token);
+    expect(mockChefService.verifyEmail).toHaveBeenCalledWith();
     expect(verifyEmailComponent.enableResend()).toBeFalse();
   });
 
@@ -80,7 +80,7 @@ describe('VerifyEmailComponent', () => {
     logoutButton?.click();
     fixture.detectChanges();
 
-    expect(mockChefService.logout).toHaveBeenCalledWith(mockChef.token);
+    expect(mockChefService.logout).toHaveBeenCalledWith();
     expect(navigateSpy).toHaveBeenCalledWith([routes.profile.path]);
   });
 });

--- a/src/app/components/profile/verify-email/verify-email.component.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.ts
@@ -57,24 +57,16 @@ export class VerifyEmailComponent implements OnInit {
   }
 
   resendVerificationEmail() {
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token !== null) {
-      this.chefService.verifyEmail(token).subscribe({
-        error: (error) => {
-          this.snackBar.open(error.message, 'Dismiss');
-        },
-      });
-    }
+    this.chefService.verifyEmail().subscribe({
+      error: (error) => {
+        this.snackBar.open(error.message, 'Dismiss');
+      },
+    });
     this.enableResend.set(false);
   }
 
   logout() {
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-    if (token !== null) {
-      this.chefService.logout(token).subscribe();
-    }
-    // Assume the user should be signed out since there's no auth token
-    localStorage.removeItem(Constants.LocalStorage.token);
+    this.chefService.logout().subscribe();
     this.router.navigate([routes.profile.path]);
   }
 }

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -103,6 +103,10 @@ export class RecipeComponent implements OnInit, OnDestroy {
         }
       }
     });
+
+    if (this.chef() === undefined) {
+      this.chefService.getChef().subscribe();
+    }
   }
 
   ngOnInit(): void {

--- a/src/app/components/recipe/recipe.component.ts
+++ b/src/app/components/recipe/recipe.component.ts
@@ -26,7 +26,6 @@ import { TermsService } from 'src/app/services/terms.service';
 import { ShorthandPipe } from '../../pipes/shorthand.pipe';
 import { RecipeRatingComponent } from '../utils/recipe-rating/recipe-rating.component';
 import { ChefService } from 'src/app/services/chef.service';
-import Constants from 'src/app/constants/constants';
 
 @Component({
   selector: 'app-recipe',
@@ -149,11 +148,9 @@ export class RecipeComponent implements OnInit, OnDestroy {
     const recipeUpdate: RecipeUpdate = {
       view: true,
     };
-    const token =
-      localStorage.getItem(Constants.LocalStorage.token) ?? undefined;
 
-    this.recipeService.updateRecipe(recipe.id, recipeUpdate, token).subscribe({
-      next: ({ token }) => {
+    this.recipeService.updateRecipe(recipe.id, recipeUpdate).subscribe({
+      next: () => {
         this.chefService.chef.update(
           (chef) =>
             chef && {
@@ -164,10 +161,6 @@ export class RecipeComponent implements OnInit, OnDestroy {
               },
             }
         );
-
-        if (token !== undefined) {
-          localStorage.setItem(Constants.LocalStorage.token, token);
-        }
       },
       error: (error) => {
         console.error(
@@ -201,13 +194,8 @@ export class RecipeComponent implements OnInit, OnDestroy {
     const recipeUpdate: RecipeUpdate = {
       rating,
     };
-    const token = localStorage.getItem(Constants.LocalStorage.token);
 
-    if (
-      this.chefService.chef() === undefined ||
-      recipeId === undefined ||
-      token === null
-    ) {
+    if (this.chef() === undefined || recipeId === undefined) {
       this.snackBar.open(
         'You must be signed in to rate this recipe',
         'Dismiss'
@@ -216,10 +204,10 @@ export class RecipeComponent implements OnInit, OnDestroy {
     }
 
     this.recipeService
-      .updateRecipe(recipeId, recipeUpdate, token)
+      .updateRecipe(recipeId, recipeUpdate)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: ({ token }) => {
+        next: () => {
           this.chefService.chef.update(
             (chef) =>
               chef && {
@@ -230,10 +218,6 @@ export class RecipeComponent implements OnInit, OnDestroy {
                 },
               }
           );
-
-          if (token !== undefined) {
-            localStorage.setItem(Constants.LocalStorage.token, token);
-          }
         },
         error: (error) => {
           this.snackBar.open(error.message, 'Dismiss');

--- a/src/app/components/utils/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/utils/recipe-card/recipe-card.component.spec.ts
@@ -109,11 +109,9 @@ describe('RecipeCardComponent', () => {
     mockRecipeService.updateRecipe.and.returnValue(of(mockToken));
     favoriteButton?.click();
     fixture.detectChanges();
-    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(
-      mockRecipe.id,
-      { isFavorite: true },
-      mockChef.token
-    );
+    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(mockRecipe.id, {
+      isFavorite: true,
+    });
     expect(recipeCardComponent.chef()?.favoriteRecipes).toContain(
       mockRecipe.id.toString()
     );
@@ -121,11 +119,9 @@ describe('RecipeCardComponent', () => {
 
     favoriteButton?.click();
     fixture.detectChanges();
-    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(
-      mockRecipe.id,
-      { isFavorite: false },
-      mockChef.token
-    );
+    expect(mockRecipeService.updateRecipe).toHaveBeenCalledWith(mockRecipe.id, {
+      isFavorite: false,
+    });
     expect(recipeCardComponent.chef()?.favoriteRecipes).not.toContain(
       mockRecipe.id.toString()
     );

--- a/src/app/components/utils/recipe-card/recipe-card.component.ts
+++ b/src/app/components/utils/recipe-card/recipe-card.component.ts
@@ -10,7 +10,6 @@ import Recipe, { RecipeUpdate } from 'src/app/models/recipe.model';
 import { RecipeService } from 'src/app/services/recipe.service';
 import { RecipeRatingComponent } from '../recipe-rating/recipe-rating.component';
 import { ChefService } from 'src/app/services/chef.service';
-import Constants from 'src/app/constants/constants';
 
 @Component({
   selector: 'app-recipe-card',
@@ -48,36 +47,26 @@ export class RecipeCardComponent {
     const recipeUpdate: RecipeUpdate = {
       isFavorite: !this.isFavorite(),
     };
-    const token =
-      localStorage.getItem(Constants.LocalStorage.token) ?? undefined;
 
-    this.recipeService
-      .updateRecipe(this.recipe().id, recipeUpdate, token)
-      .subscribe({
-        next: ({ token }) => {
-          const newFavoriteRecipes = this.isFavorite()
-            ? this.chef()?.favoriteRecipes?.filter(
-                (recipeId) => recipeId !== this.recipe().id.toString()
-              )
-            : this.chef()?.favoriteRecipes?.concat([
-                this.recipe().id.toString(),
-              ]);
-          this.chef.update(
-            (chef) =>
-              chef && {
-                ...chef,
-                favoriteRecipes: newFavoriteRecipes ?? [],
-              }
-          );
-
-          if (token !== undefined) {
-            localStorage.setItem(Constants.LocalStorage.token, token);
-          }
-        },
-        error: (error) => {
-          this.snackBar.open(error.message, 'Dismiss');
-        },
-      });
+    this.recipeService.updateRecipe(this.recipe().id, recipeUpdate).subscribe({
+      next: () => {
+        const newFavoriteRecipes = this.isFavorite()
+          ? this.chef()?.favoriteRecipes?.filter(
+              (recipeId) => recipeId !== this.recipe().id.toString()
+            )
+          : this.chef()?.favoriteRecipes?.concat([this.recipe().id.toString()]);
+        this.chef.update(
+          (chef) =>
+            chef && {
+              ...chef,
+              favoriteRecipes: newFavoriteRecipes ?? [],
+            }
+        );
+      },
+      error: (error) => {
+        this.snackBar.open(error.message, 'Dismiss');
+      },
+    });
   }
 
   onRate(rating: number) {
@@ -85,9 +74,8 @@ export class RecipeCardComponent {
     const recipeUpdate: RecipeUpdate = {
       rating,
     };
-    const token = localStorage.getItem(Constants.LocalStorage.token);
 
-    if (this.chef() === undefined || token === null) {
+    if (this.chef() === undefined) {
       this.snackBar.open(
         'You must be signed in to rate this recipe',
         'Dismiss'
@@ -95,8 +83,8 @@ export class RecipeCardComponent {
       return;
     }
 
-    this.recipeService.updateRecipe(recipeId, recipeUpdate, token).subscribe({
-      next: ({ token }) => {
+    this.recipeService.updateRecipe(recipeId, recipeUpdate).subscribe({
+      next: () => {
         this.chef.update(
           (chef) =>
             chef && {
@@ -116,10 +104,6 @@ export class RecipeCardComponent {
               error.message
             );
           });
-
-        if (token !== undefined) {
-          localStorage.setItem(Constants.LocalStorage.token, token);
-        }
       },
       error: (error) => {
         this.snackBar.open(error.message, 'Dismiss');

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -107,4 +107,28 @@ describe('authGuard', () => {
       done();
     });
   });
+
+  it("should redirect to the login page if the user didn't verify their email", (done) => {
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
+    mockChefService.chef.and.returnValue(undefined);
+    mockChefService.getChef.and.returnValue(
+      of({
+        ...mockChef,
+        emailVerified: false,
+      })
+    );
+    const guardResult = executeGuard(route, state) as Observable<UrlTree>;
+
+    guardResult.subscribe((result) => {
+      expect(result).toBeInstanceOf(UrlTree);
+      expect(result.queryParams).toEqual({ next: state.url });
+      expect(createUrlTreeSpy).toHaveBeenCalledWith(
+        [`/${profileRoutes.login.path}`],
+        {
+          queryParams: { next: state.url },
+        }
+      );
+      done();
+    });
+  });
 });

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -32,7 +32,7 @@ describe('authGuard', () => {
   const localStorageProto = Object.getPrototypeOf(localStorage);
 
   beforeEach(() => {
-    mockChefService = jasmine.createSpyObj('ChefService', ['getChef']);
+    mockChefService = jasmine.createSpyObj('ChefService', ['chef', 'getChef']);
     createUrlTreeSpy = spyOn(
       Router.prototype,
       'createUrlTree'
@@ -52,8 +52,18 @@ describe('authGuard', () => {
     expect(executeGuard).toBeTruthy();
   });
 
+  it('should return true if the user is already authenticated', () => {
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
+    mockChefService.chef.and.returnValue(mockChef);
+    mockChefService.getChef.and.returnValue(of(mockChef));
+    const guardResult = executeGuard(route, state) as Observable<boolean>;
+
+    expect(guardResult).toBeTrue();
+  });
+
   it('should return true if the user is authenticated', (done) => {
     spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
+    mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(of(mockChef));
     const guardResult = executeGuard(route, state) as Observable<boolean>;
 
@@ -63,8 +73,9 @@ describe('authGuard', () => {
     });
   });
 
-  it("should redirect to the login page if there's no token in localStorage", (done) => {
+  it("should redirect to the login page if there's no token in localStorage", () => {
     spyOn(localStorageProto, 'getItem').and.returnValue(null);
+    mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(throwError(() => 'mock error'));
     const guardResult = executeGuard(route, state) as UrlTree;
 
@@ -76,11 +87,11 @@ describe('authGuard', () => {
         queryParams: { next: state.url },
       }
     );
-    done();
   });
 
   it("should redirect to the login page if the user isn't authenticated", (done) => {
     spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
+    mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(throwError(() => 'mock error'));
     const guardResult = executeGuard(route, state) as Observable<UrlTree>;
 

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -23,7 +23,7 @@ export const authGuard: CanActivateFn = (_route, state) => {
     return true;
   }
 
-  return chefService.getChef(token).pipe(
+  return chefService.getChef().pipe(
     map(() => true),
     catchError(() => of(loginRedirect))
   );

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -19,6 +19,8 @@ export const authGuard: CanActivateFn = (_route, state) => {
 
   if (token === null) {
     return loginRedirect;
+  } else if (chefService.chef() !== undefined) {
+    return true;
   }
 
   return chefService.getChef(token).pipe(

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -24,7 +24,7 @@ export const authGuard: CanActivateFn = (_route, state) => {
   }
 
   return chefService.getChef().pipe(
-    map(() => true),
+    map(({ emailVerified }) => emailVerified || loginRedirect),
     catchError(() => of(loginRedirect))
   );
 };

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -33,6 +33,13 @@ describe('ChefService', () => {
     'An unexpected error occurred. The server may be down or there may be network issues. ' +
     'Please try again later.';
 
+  const mockLocalStorage = (token: string | null = mockChef.token) => {
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => {});
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
@@ -55,7 +62,8 @@ describe('ChefService', () => {
   });
 
   it('should get a chef', async () => {
-    const chefPromise = firstValueFrom(chefService.getChef(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.getChef());
 
     const req = httpTestingController.expectOne({
       method: 'GET',
@@ -71,7 +79,8 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the GET chef API fails', async () => {
-    const chefPromise = firstValueFrom(chefService.getChef(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.getChef());
 
     const req = httpTestingController.expectOne({
       method: 'GET',
@@ -84,6 +93,7 @@ describe('ChefService', () => {
   });
 
   it('should create a chef', async () => {
+    mockLocalStorage();
     const credentials: LoginCredentials = {
       email: mockChef.email,
       password: 'password',
@@ -116,6 +126,7 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.createChef(credentials));
 
     const req = httpTestingController.expectOne({
@@ -134,9 +145,8 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'newpassword',
     };
-    const chefPromise = firstValueFrom(
-      chefService.updateChef(fields, mockChef.token)
-    );
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
       method: 'PATCH',
@@ -153,9 +163,10 @@ describe('ChefService', () => {
 
   it('should update a chef without a token', async () => {
     const fields: ChefUpdate = {
-      type: ChefUpdateType.Email,
+      type: ChefUpdateType.Password,
       email: mockChef.email,
     };
+    mockLocalStorage(null);
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
@@ -174,6 +185,7 @@ describe('ChefService', () => {
       type: ChefUpdateType.Email,
       email: mockChef.email,
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
@@ -186,7 +198,8 @@ describe('ChefService', () => {
   });
 
   it('should delete a chef', async () => {
-    const chefPromise = firstValueFrom(chefService.deleteChef(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.deleteChef());
 
     const req = httpTestingController.expectOne({
       method: 'DELETE',
@@ -202,7 +215,8 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the DELETE chef API fails', async () => {
-    const chefPromise = firstValueFrom(chefService.deleteChef(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.deleteChef());
 
     const req = httpTestingController.expectOne({
       method: 'DELETE',
@@ -215,7 +229,8 @@ describe('ChefService', () => {
   });
 
   it('should verify an email', async () => {
-    const chefPromise = firstValueFrom(chefService.verifyEmail(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.verifyEmail());
 
     const req = httpTestingController.expectOne({
       method: 'POST',
@@ -231,7 +246,8 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the verify email API fails', async () => {
-    const chefPromise = firstValueFrom(chefService.verifyEmail(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.verifyEmail());
 
     const req = httpTestingController.expectOne({
       method: 'POST',
@@ -247,6 +263,7 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.login(credentials));
 
     const req = httpTestingController.expectOne({
@@ -275,6 +292,7 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.login(credentials));
 
     const req = httpTestingController.expectOne({
@@ -288,7 +306,8 @@ describe('ChefService', () => {
   });
 
   it('should logout', async () => {
-    const chefPromise = firstValueFrom(chefService.logout(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.logout());
 
     const req = httpTestingController.expectOne({
       method: 'POST',
@@ -305,7 +324,8 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the logout API fails', async () => {
-    const chefPromise = firstValueFrom(chefService.logout(mockChef.token));
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.logout());
 
     const req = httpTestingController.expectOne({
       method: 'POST',

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -47,7 +47,7 @@ export class ChefService {
       .pipe(
         tap((chef) => {
           localStorage.setItem(Constants.LocalStorage.token, chef.token);
-          this.chef.set(chef);
+          this.chef.set(chef.emailVerified ? chef : undefined);
         }),
         catchError((error) => {
           localStorage.removeItem(Constants.LocalStorage.token);

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -41,6 +41,13 @@ describe('RecipeService', () => {
     })
   );
 
+  const mockLocalStorage = (token: string | null = mockChef.token) => {
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => {});
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => {});
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
@@ -54,6 +61,7 @@ describe('RecipeService', () => {
         },
       ],
     });
+
     recipeService = TestBed.inject(RecipeService);
     recentRecipesDB = TestBed.inject(RecentRecipesDB);
 
@@ -217,8 +225,9 @@ describe('RecipeService', () => {
       view: true,
       isFavorite: true,
     };
+    mockLocalStorage();
     const recipePromise = firstValueFrom(
-      recipeService.updateRecipe(id, fields, mockChef.token)
+      recipeService.updateRecipe(id, fields)
     );
 
     const req = httpTestingController.expectOne({
@@ -240,6 +249,7 @@ describe('RecipeService', () => {
     const fields: RecipeUpdate = {
       view: true,
     };
+    mockLocalStorage(null);
     const recipePromise = firstValueFrom(
       recipeService.updateRecipe(id, fields)
     );
@@ -269,7 +279,9 @@ describe('RecipeService', () => {
       method: 'PATCH',
       url: `${baseUrl}/${id}`,
     });
-    expect(req.request.headers.get('Authorization')).toBeNull();
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     expect(req.request.body).toBe(fields);
     req.error(mockError);
 

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -81,14 +81,12 @@ export class RecipeService {
       );
   }
 
-  updateRecipe(
-    id: number,
-    fields: RecipeUpdate,
-    token?: string
-  ): Observable<Token> {
+  updateRecipe(id: number, fields: RecipeUpdate): Observable<Token> {
     if (this.isMocking) {
       return this.getMockToken();
     }
+
+    const token = localStorage.getItem(Constants.LocalStorage.token);
 
     return this.http
       .patch<Token>(
@@ -96,11 +94,18 @@ export class RecipeService {
         fields,
         {
           headers: {
-            ...(token !== undefined && this.authHeader(token)),
+            ...(token !== null && this.authHeader(token)),
           },
         }
       )
-      .pipe(catchError(handleError));
+      .pipe(
+        tap(({ token }) => {
+          if (token !== undefined) {
+            localStorage.setItem(Constants.LocalStorage.token, token);
+          }
+        }),
+        catchError(handleError)
+      );
   }
 
   // Load a sample recipe to avoid hitting the API while testing the UI


### PR DESCRIPTION
## Signed Out

<div>
  <img src="https://github.com/user-attachments/assets/b4baa22a-e5d3-4777-bb55-4cb3a1c4b0b4" alt="home-offline-sm" width="300">
  <img src="https://github.com/user-attachments/assets/8a9a999b-40eb-42a6-9e66-189bc9b4ef8e" alt="home-offline-lg" width="600">
</div>

## Signed In

<div>
  <img src="https://github.com/user-attachments/assets/3ca4636a-4706-4f0c-abde-b634dacab7b5" alt="home-online-sm" width="300">
  <img src="https://github.com/user-attachments/assets/bcadd8e4-77e2-4b0d-88ad-a87501f1d763" alt="home-online-lg" width="600">
</div>
<div>
  <img src="https://github.com/user-attachments/assets/a2fdc6c6-e07b-40b0-9c41-5fb085adacd8" alt="home-online-sm-favorites" width="300">
  <img src="https://github.com/user-attachments/assets/7f617651-fafa-47ab-b498-570537ecdb70" alt="home-online-lg-favorites" width="600">
</div>
<div>
  <img src="https://github.com/user-attachments/assets/9fd10f30-8090-4084-a5af-b8eca1de0bbb" alt="home-online-sm-recents" width="300">
  <img src="https://github.com/user-attachments/assets/7719d9bf-4fef-4a68-a3ce-ad523fbbe049" alt="home-online-lg-recents" width="600">
</div>
<div>
  <img src="https://github.com/user-attachments/assets/03ce0a4c-122f-4d84-8502-c4507b6b3ab5" alt="home-online-sm-ratings" width="300">
  <img src="https://github.com/user-attachments/assets/e0b83028-3daa-4ea6-a1f9-3f2037615f38" alt="home-online-lg-ratings" width="600">
</div>

_The web implementation of #5, #10, & #311_

The home page accordions have been created, which means now is the time to release the profile page in prod to see how much of it doesn't work. /s

I did catch some bugs, such as missing the chef information when refreshing certain pages, or how we handle cases when the user didn't verify their email. So hopefully that will ease the testing process. My main goal is to do one more E2E test, but on mobile, to see if the text fields are mobile-friendly. I also want to confirm if autofill works as expected, and I can change my password directly from the password manager.

It took some time on all platforms to figure out how to fetch all the recipe cards in parallel when we open the accordions, but it was especially interesting here. I wanted the equivalent of `Promise.allSettled` for observables. `forkJoin` does the equivalent of `Promise.all`, in that it makes all the requests in parallel, but fails if at least one of the APIs fails. ChatGPT suggested using `materialize` to send each API result in a notification, but `forkJoin` only emits the completion notification, which doesn't contain the actual API response. After some more back and forth, I figured out I can use `zip` instead of `forkJoin` to capture the next notification with the responses. Despite ChatGPT's hesitation, it also works if any of the APIs fail. The entire observable won't fail. Instead, we'd get all the success and failure notifications for each API all at once.

I'll still need to update the screenshots in the README and webmanifest, but that can be done in a separate PR once I confirm everything else is working.