### PR TITLE
Use cookies instead of localStorage for authentication

### DIFF
--- a/src/app/components/profile/delete-account/delete-account.component.spec.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.spec.ts
@@ -34,11 +34,6 @@ describe('DeleteAccountComponent', () => {
       ],
     }).compileComponents();
 
-    const localStorageProto = Object.getPrototypeOf(localStorage);
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
-    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
-    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
-
     router = TestBed.inject(Router);
     spyOnProperty(router, 'lastSuccessfulNavigation').and.returnValue({
       extras: { state: { email: mockChef.email } },

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -9,7 +9,6 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 import { AuthState, ProfileAction } from 'src/app/models/profile.model';
 import { profileRoutes } from 'src/app/app-routing.module';
-import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
 
 @Component({
@@ -48,11 +47,7 @@ export class ProfileComponent implements OnInit {
 
   ngOnInit(): void {
     // Check if the user is authenticated every time the profile tab is launched
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-
-    if (token === null) {
-      this.authState.set(AuthState.Unauthenticated);
-    } else if (
+    if (
       this.totalRecipesFavorited() > 0 ||
       this.totalRecipesViewed() > 0 ||
       this.totalRecipesRated() > 0
@@ -68,7 +63,13 @@ export class ProfileComponent implements OnInit {
         },
         error: (error) => {
           this.authState.set(AuthState.Unauthenticated);
-          this.snackBar.open(error.message, 'Dismiss');
+
+          // Don't show the snackbar if the token is missing
+          if (
+            error.message !== 'Missing the Firebase ID token from the request'
+          ) {
+            this.snackBar.open(error.message, 'Dismiss');
+          }
         },
       });
     }

--- a/src/app/components/profile/update-email/update-email.component.spec.ts
+++ b/src/app/components/profile/update-email/update-email.component.spec.ts
@@ -8,7 +8,7 @@ import { of } from 'rxjs';
 
 import { UpdateEmailComponent } from './update-email.component';
 import { ChefService } from 'src/app/services/chef.service';
-import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
+import { mockChefEmailResponse } from 'src/app/models/profile.mock';
 import { ChefUpdateType } from 'src/app/models/profile.model';
 
 describe('UpdateEmailComponent', () => {
@@ -31,11 +31,6 @@ describe('UpdateEmailComponent', () => {
         },
       ],
     }).compileComponents();
-
-    const localStorageProto = Object.getPrototypeOf(localStorage);
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
-    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
-    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
 
     fixture = TestBed.createComponent(UpdateEmailComponent);
     updateEmailComponent = fixture.componentInstance;

--- a/src/app/components/profile/update-password/update-password.component.spec.ts
+++ b/src/app/components/profile/update-password/update-password.component.spec.ts
@@ -35,11 +35,6 @@ describe('UpdatePasswordComponent', () => {
       ],
     }).compileComponents();
 
-    const localStorageProto = Object.getPrototypeOf(localStorage);
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
-    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
-    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
-
     router = TestBed.inject(Router);
     spyOnProperty(router, 'lastSuccessfulNavigation').and.returnValue({
       extras: { state: { email: mockChef.email } },

--- a/src/app/components/profile/verify-email/verify-email.component.spec.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.spec.ts
@@ -9,7 +9,7 @@ import { of } from 'rxjs';
 
 import { VerifyEmailComponent } from './verify-email.component';
 import { ChefService } from 'src/app/services/chef.service';
-import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
+import { mockChefEmailResponse } from 'src/app/models/profile.mock';
 import { routes } from 'src/app/app-routing.module';
 
 describe('VerifyEmailComponent', () => {
@@ -36,11 +36,6 @@ describe('VerifyEmailComponent', () => {
         },
       ],
     }).compileComponents();
-
-    const localStorageProto = Object.getPrototypeOf(localStorage);
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
-    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
-    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
 
     router = TestBed.inject(Router);
     fixture = TestBed.createComponent(VerifyEmailComponent);

--- a/src/app/components/utils/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/utils/recipe-card/recipe-card.component.spec.ts
@@ -47,11 +47,6 @@ describe('RecipeCardComponent', () => {
       ],
     }).compileComponents();
 
-    const localStorageProto = Object.getPrototypeOf(localStorage);
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
-    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
-    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
-
     fixture = TestBed.createComponent(RecipeCardComponent);
     recipeCardComponent = fixture.componentInstance;
     fixture.componentRef.setInput('recipe', mockRecipe); // input is required

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -17,7 +17,6 @@ abstract class Constants {
     'Mixing things up... 🥘',
     'Shaking things up... 🍲',
   ];
-  static readonly noTokenFound = 'No token found';
 
   // APIs
   static readonly recipesPath = '/api/recipes';
@@ -29,7 +28,6 @@ abstract class Constants {
 
   static LocalStorage = class {
     static readonly terms = 'terms';
-    static readonly token = 'token';
     static readonly theme = 'theme';
   };
 

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -13,7 +13,6 @@ import { authGuard } from './auth.guard';
 import { ChefService } from '../services/chef.service';
 import { mockChef } from '../models/profile.mock';
 import { profileRoutes } from '../app-routing.module';
-import { mockToken } from '../models/recipe.mock';
 
 describe('authGuard', () => {
   const executeGuard: CanActivateFn = (...guardParameters) =>
@@ -29,7 +28,6 @@ describe('authGuard', () => {
       navigationExtras?: UrlCreationOptions
     ) => UrlTree
   >;
-  const localStorageProto = Object.getPrototypeOf(localStorage);
 
   beforeEach(() => {
     mockChefService = jasmine.createSpyObj('ChefService', ['chef', 'getChef']);
@@ -53,7 +51,6 @@ describe('authGuard', () => {
   });
 
   it('should return true if the user is already authenticated', () => {
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(mockChef);
     mockChefService.getChef.and.returnValue(of(mockChef));
     const guardResult = executeGuard(route, state) as Observable<boolean>;
@@ -62,7 +59,6 @@ describe('authGuard', () => {
   });
 
   it('should return true if the user is authenticated', (done) => {
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(of(mockChef));
     const guardResult = executeGuard(route, state) as Observable<boolean>;
@@ -73,24 +69,7 @@ describe('authGuard', () => {
     });
   });
 
-  it("should redirect to the login page if there's no token in localStorage", () => {
-    spyOn(localStorageProto, 'getItem').and.returnValue(null);
-    mockChefService.chef.and.returnValue(undefined);
-    mockChefService.getChef.and.returnValue(throwError(() => 'mock error'));
-    const guardResult = executeGuard(route, state) as UrlTree;
-
-    expect(guardResult).toBeInstanceOf(UrlTree);
-    expect(guardResult.queryParams).toEqual({ next: state.url });
-    expect(createUrlTreeSpy).toHaveBeenCalledWith(
-      [`/${profileRoutes.login.path}`],
-      {
-        queryParams: { next: state.url },
-      }
-    );
-  });
-
   it("should redirect to the login page if the user isn't authenticated", (done) => {
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(throwError(() => 'mock error'));
     const guardResult = executeGuard(route, state) as Observable<UrlTree>;
@@ -109,7 +88,6 @@ describe('authGuard', () => {
   });
 
   it("should redirect to the login page if the user didn't verify their email", (done) => {
-    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(
       of({

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -4,22 +4,18 @@ import { catchError, map, of } from 'rxjs';
 
 import { ChefService } from '../services/chef.service';
 import { profileRoutes } from '../app-routing.module';
-import Constants from '../constants/constants';
 
 // If the user is authenticated, navigate to the route. Otherwise, redirect to the login page.
 export const authGuard: CanActivateFn = (_route, state) => {
   const router = inject(Router);
   const chefService = inject(ChefService);
 
-  const token = localStorage.getItem(Constants.LocalStorage.token);
   const loginRedirect = router.createUrlTree([`/${profileRoutes.login.path}`], {
     // state.url contains the full path, whereas route.url only contains the child path
     queryParams: { next: state.url },
   });
 
-  if (token === null) {
-    return loginRedirect;
-  } else if (chefService.chef() !== undefined) {
+  if (chefService.chef() !== undefined) {
     return true;
   }
 

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -33,13 +33,6 @@ describe('ChefService', () => {
     'An unexpected error occurred. The server may be down or there may be network issues. ' +
     'Please try again later.';
 
-  const mockLocalStorage = (token: string | null = mockChef.token) => {
-    const localStorageProto = Object.getPrototypeOf(localStorage);
-    spyOn(localStorageProto, 'getItem').and.returnValue(token);
-    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
-    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
-  };
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
@@ -62,16 +55,12 @@ describe('ChefService', () => {
   });
 
   it('should get a chef', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.getChef());
 
     const req = httpTestingController.expectOne({
       method: 'GET',
       url: baseUrl,
     });
-    expect(req.request.headers.get('Authorization')).toBe(
-      `Bearer ${mockChef.token}`
-    );
     req.flush(mockChef);
 
     await expectAsync(chefPromise).toBeResolvedTo(mockChef);
@@ -79,7 +68,6 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the GET chef API fails', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.getChef());
 
     const req = httpTestingController.expectOne({
@@ -93,7 +81,6 @@ describe('ChefService', () => {
   });
 
   it('should create a chef', async () => {
-    mockLocalStorage();
     const credentials: LoginCredentials = {
       email: mockChef.email,
       password: 'password',
@@ -104,7 +91,6 @@ describe('ChefService', () => {
       method: 'POST',
       url: baseUrl,
     });
-    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(credentials);
     const loginResponse = mockLoginResponse(false);
     req.flush(loginResponse);
@@ -126,7 +112,6 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.createChef(credentials));
 
     const req = httpTestingController.expectOne({
@@ -145,16 +130,12 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'newpassword',
     };
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
       method: 'PATCH',
       url: baseUrl,
     });
-    expect(req.request.headers.get('Authorization')).toBe(
-      `Bearer ${mockChef.token}`
-    );
     expect(req.request.body).toBe(fields);
     req.flush(mockChefEmailResponse);
 
@@ -166,14 +147,12 @@ describe('ChefService', () => {
       type: ChefUpdateType.Password,
       email: mockChef.email,
     };
-    mockLocalStorage(null);
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
       method: 'PATCH',
       url: baseUrl,
     });
-    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(fields);
     req.flush(mockChefEmailResponse);
 
@@ -185,7 +164,6 @@ describe('ChefService', () => {
       type: ChefUpdateType.Email,
       email: mockChef.email,
     };
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
@@ -198,16 +176,12 @@ describe('ChefService', () => {
   });
 
   it('should delete a chef', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.deleteChef());
 
     const req = httpTestingController.expectOne({
       method: 'DELETE',
       url: baseUrl,
     });
-    expect(req.request.headers.get('Authorization')).toBe(
-      `Bearer ${mockChef.token}`
-    );
     req.flush(null);
 
     await expectAsync(chefPromise).toBeResolvedTo(null);
@@ -215,7 +189,6 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the DELETE chef API fails', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.deleteChef());
 
     const req = httpTestingController.expectOne({
@@ -229,16 +202,12 @@ describe('ChefService', () => {
   });
 
   it('should verify an email', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.verifyEmail());
 
     const req = httpTestingController.expectOne({
       method: 'POST',
       url: `${baseUrl}/verify`,
     });
-    expect(req.request.headers.get('Authorization')).toBe(
-      `Bearer ${mockChef.token}`
-    );
     expect(req.request.body).toBeNull();
     req.flush(mockChefEmailResponse);
 
@@ -246,7 +215,6 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the verify email API fails', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.verifyEmail());
 
     const req = httpTestingController.expectOne({
@@ -263,14 +231,12 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.login(credentials));
 
     const req = httpTestingController.expectOne({
       method: 'POST',
       url: `${baseUrl}/login`,
     });
-    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(credentials);
     const loginResponse = mockLoginResponse();
     req.flush(loginResponse);
@@ -292,7 +258,6 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.login(credentials));
 
     const req = httpTestingController.expectOne({
@@ -306,16 +271,12 @@ describe('ChefService', () => {
   });
 
   it('should logout', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.logout());
 
     const req = httpTestingController.expectOne({
       method: 'POST',
       url: `${baseUrl}/logout`,
     });
-    expect(req.request.headers.get('Authorization')).toBe(
-      `Bearer ${mockChef.token}`
-    );
     expect(req.request.body).toBeNull();
     req.flush(null);
 
@@ -324,7 +285,6 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the logout API fails', async () => {
-    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.logout());
 
     const req = httpTestingController.expectOne({

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -19,7 +19,6 @@ import recipeFilterParams from './recipe-filter-params';
 import RecentRecipesDB, {
   RECENT_RECIPES_DB_NAME,
 } from '../helpers/recent-recipes-db';
-import { mockChef } from '../models/profile.mock';
 
 describe('RecipeService', () => {
   let recipeService: RecipeService;
@@ -40,13 +39,6 @@ describe('RecipeService', () => {
       isFavorite: false,
     })
   );
-
-  const mockLocalStorage = (token: string | null = mockChef.token) => {
-    const localStorageProto = Object.getPrototypeOf(localStorage);
-    spyOn(localStorageProto, 'getItem').and.returnValue(token);
-    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
-    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
-  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -225,7 +217,6 @@ describe('RecipeService', () => {
       view: true,
       isFavorite: true,
     };
-    mockLocalStorage();
     const recipePromise = firstValueFrom(
       recipeService.updateRecipe(id, fields)
     );
@@ -234,9 +225,6 @@ describe('RecipeService', () => {
       method: 'PATCH',
       url: `${baseUrl}/${id}`,
     });
-    expect(req.request.headers.get('Authorization')).toBe(
-      `Bearer ${mockChef.token}`
-    );
     expect(req.request.body).toBe(fields);
     req.flush(mockToken);
 
@@ -249,7 +237,6 @@ describe('RecipeService', () => {
     const fields: RecipeUpdate = {
       view: true,
     };
-    mockLocalStorage(null);
     const recipePromise = firstValueFrom(
       recipeService.updateRecipe(id, fields)
     );
@@ -258,7 +245,6 @@ describe('RecipeService', () => {
       method: 'PATCH',
       url: `${baseUrl}/${id}`,
     });
-    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(fields);
     req.flush({});
 
@@ -271,7 +257,6 @@ describe('RecipeService', () => {
     const fields: RecipeUpdate = {
       isFavorite: false,
     };
-    mockLocalStorage();
     const recipePromise = firstValueFrom(
       recipeService.updateRecipe(id, fields)
     );
@@ -280,9 +265,6 @@ describe('RecipeService', () => {
       method: 'PATCH',
       url: `${baseUrl}/${id}`,
     });
-    expect(req.request.headers.get('Authorization')).toBe(
-      `Bearer ${mockChef.token}`
-    );
     expect(req.request.body).toBe(fields);
     req.error(mockError);
 

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -86,26 +86,15 @@ export class RecipeService {
       return this.getMockToken();
     }
 
-    const token = localStorage.getItem(Constants.LocalStorage.token);
-
     return this.http
       .patch<Token>(
         `${environment.serverBaseUrl}${Constants.recipesPath}/${id}`,
         fields,
         {
-          headers: {
-            ...(token !== null && this.authHeader(token)),
-          },
+          withCredentials: true,
         }
       )
-      .pipe(
-        tap(({ token }) => {
-          if (token !== undefined) {
-            localStorage.setItem(Constants.LocalStorage.token, token);
-          }
-        }),
-        catchError(handleError)
-      );
+      .pipe(catchError(handleError));
   }
 
   // Load a sample recipe to avoid hitting the API while testing the UI
@@ -159,12 +148,6 @@ export class RecipeService {
         this.mockLoading ? 10_000 : 0
       );
     });
-  }
-
-  private authHeader(token: string) {
-    return {
-      Authorization: `Bearer ${token}`,
-    };
   }
 
   // IndexedDB methods


### PR DESCRIPTION
<img width="810" height="31" alt="image" src="https://github.com/user-attachments/assets/d630b3a5-cce3-4d44-b157-bff91e2fe737" />


These are the corresponding web changes to https://github.com/Abhiek187/ez-recipes-server/pull/465. All references to the token in localStorage are replaced with `useCredential` to automatically save and send cookies for authenticated requests. Cookies won't be sent on unauthenticated requests, such as recipe or term APIs (besides updating a recipe). This reduces the amount of code quite a bit, which I always like. 😊

The only downside is that since this is an HttpOnly cookie, the browser can't check its existence directly. To check if the user is authenticated, outside of signals, the browser must make an API call. This may incur some additional usage of the API, but hopefully it doesn't put us over the rate limit.