### PR TITLE
Revert "Use cookies instead of localStorage for authentication"

### DIFF
--- a/src/app/components/profile/delete-account/delete-account.component.spec.ts
+++ b/src/app/components/profile/delete-account/delete-account.component.spec.ts
@@ -34,6 +34,11 @@ describe('DeleteAccountComponent', () => {
       ],
     }).compileComponents();
 
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
+
     router = TestBed.inject(Router);
     spyOnProperty(router, 'lastSuccessfulNavigation').and.returnValue({
       extras: { state: { email: mockChef.email } },

--- a/src/app/components/profile/profile.component.spec.ts
+++ b/src/app/components/profile/profile.component.spec.ts
@@ -12,13 +12,11 @@ import {
   RouterLink,
   RouterModule,
 } from '@angular/router';
-import { of, throwError } from 'rxjs';
 
 import { ProfileComponent } from './profile.component';
 import { AuthState } from 'src/app/models/profile.model';
 import { profileRoutes, routes } from 'src/app/app-routing.module';
 import { mockChef } from 'src/app/models/profile.mock';
-import { ChefService } from 'src/app/services/chef.service';
 
 describe('ProfileComponent', () => {
   let profileComponent: ProfileComponent;
@@ -27,30 +25,20 @@ describe('ProfileComponent', () => {
   let router: Router;
   let location: Location;
 
-  let mockChefService: jasmine.SpyObj<ChefService>;
-
   beforeEach(async () => {
-    mockChefService = jasmine.createSpyObj('ChefService', [
-      'chef',
-      'getChef',
-      'logout',
-    ]);
-    mockChefService.chef.and.returnValue(undefined);
-    mockChefService.getChef.and.returnValue(throwError(() => 'mock error'));
-    mockChefService.logout.and.returnValue(of(null));
-
     await TestBed.configureTestingModule({
       imports: [ProfileComponent, RouterModule.forRoot([])],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
         provideRouter(Object.values(routes)),
-        {
-          provide: ChefService,
-          useValue: mockChefService,
-        },
       ],
     }).compileComponents();
+
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(null);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
 
     router = TestBed.inject(Router);
     location = TestBed.inject(Location);
@@ -86,7 +74,7 @@ describe('ProfileComponent', () => {
 
   it('should show the profile page if the user is authenticated', async () => {
     profileComponent.authState.set(AuthState.Authenticated);
-    mockChefService.chef.and.returnValue(mockChef);
+    profileComponent.chef.set(mockChef);
     fixture.detectChanges();
 
     const profileStats = rootElement.querySelector('.profile-stats');

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -9,6 +9,7 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 import { AuthState, ProfileAction } from 'src/app/models/profile.model';
 import { profileRoutes } from 'src/app/app-routing.module';
+import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
 
 @Component({
@@ -47,7 +48,11 @@ export class ProfileComponent implements OnInit {
 
   ngOnInit(): void {
     // Check if the user is authenticated every time the profile tab is launched
-    if (
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+
+    if (token === null) {
+      this.authState.set(AuthState.Unauthenticated);
+    } else if (
       this.totalRecipesFavorited() > 0 ||
       this.totalRecipesViewed() > 0 ||
       this.totalRecipesRated() > 0
@@ -63,13 +68,7 @@ export class ProfileComponent implements OnInit {
         },
         error: (error) => {
           this.authState.set(AuthState.Unauthenticated);
-
-          // Don't show the snackbar if the token is missing
-          if (
-            error.message !== 'Missing the Firebase ID token from the request'
-          ) {
-            this.snackBar.open(error.message, 'Dismiss');
-          }
+          this.snackBar.open(error.message, 'Dismiss');
         },
       });
     }

--- a/src/app/components/profile/update-email/update-email.component.spec.ts
+++ b/src/app/components/profile/update-email/update-email.component.spec.ts
@@ -8,7 +8,7 @@ import { of } from 'rxjs';
 
 import { UpdateEmailComponent } from './update-email.component';
 import { ChefService } from 'src/app/services/chef.service';
-import { mockChefEmailResponse } from 'src/app/models/profile.mock';
+import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
 import { ChefUpdateType } from 'src/app/models/profile.model';
 
 describe('UpdateEmailComponent', () => {
@@ -31,6 +31,11 @@ describe('UpdateEmailComponent', () => {
         },
       ],
     }).compileComponents();
+
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
 
     fixture = TestBed.createComponent(UpdateEmailComponent);
     updateEmailComponent = fixture.componentInstance;

--- a/src/app/components/profile/update-password/update-password.component.spec.ts
+++ b/src/app/components/profile/update-password/update-password.component.spec.ts
@@ -35,6 +35,11 @@ describe('UpdatePasswordComponent', () => {
       ],
     }).compileComponents();
 
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
+
     router = TestBed.inject(Router);
     spyOnProperty(router, 'lastSuccessfulNavigation').and.returnValue({
       extras: { state: { email: mockChef.email } },

--- a/src/app/components/profile/verify-email/verify-email.component.spec.ts
+++ b/src/app/components/profile/verify-email/verify-email.component.spec.ts
@@ -9,7 +9,7 @@ import { of } from 'rxjs';
 
 import { VerifyEmailComponent } from './verify-email.component';
 import { ChefService } from 'src/app/services/chef.service';
-import { mockChefEmailResponse } from 'src/app/models/profile.mock';
+import { mockChef, mockChefEmailResponse } from 'src/app/models/profile.mock';
 import { routes } from 'src/app/app-routing.module';
 
 describe('VerifyEmailComponent', () => {
@@ -36,6 +36,11 @@ describe('VerifyEmailComponent', () => {
         },
       ],
     }).compileComponents();
+
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
 
     router = TestBed.inject(Router);
     fixture = TestBed.createComponent(VerifyEmailComponent);

--- a/src/app/components/utils/recipe-card/recipe-card.component.spec.ts
+++ b/src/app/components/utils/recipe-card/recipe-card.component.spec.ts
@@ -47,6 +47,11 @@ describe('RecipeCardComponent', () => {
       ],
     }).compileComponents();
 
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockChef.token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
+
     fixture = TestBed.createComponent(RecipeCardComponent);
     recipeCardComponent = fixture.componentInstance;
     fixture.componentRef.setInput('recipe', mockRecipe); // input is required

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -17,6 +17,7 @@ abstract class Constants {
     'Mixing things up... 🥘',
     'Shaking things up... 🍲',
   ];
+  static readonly noTokenFound = 'No token found';
 
   // APIs
   static readonly recipesPath = '/api/recipes';
@@ -28,6 +29,7 @@ abstract class Constants {
 
   static LocalStorage = class {
     static readonly terms = 'terms';
+    static readonly token = 'token';
     static readonly theme = 'theme';
   };
 

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -13,6 +13,7 @@ import { authGuard } from './auth.guard';
 import { ChefService } from '../services/chef.service';
 import { mockChef } from '../models/profile.mock';
 import { profileRoutes } from '../app-routing.module';
+import { mockToken } from '../models/recipe.mock';
 
 describe('authGuard', () => {
   const executeGuard: CanActivateFn = (...guardParameters) =>
@@ -28,6 +29,7 @@ describe('authGuard', () => {
       navigationExtras?: UrlCreationOptions
     ) => UrlTree
   >;
+  const localStorageProto = Object.getPrototypeOf(localStorage);
 
   beforeEach(() => {
     mockChefService = jasmine.createSpyObj('ChefService', ['chef', 'getChef']);
@@ -51,6 +53,7 @@ describe('authGuard', () => {
   });
 
   it('should return true if the user is already authenticated', () => {
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(mockChef);
     mockChefService.getChef.and.returnValue(of(mockChef));
     const guardResult = executeGuard(route, state) as Observable<boolean>;
@@ -59,6 +62,7 @@ describe('authGuard', () => {
   });
 
   it('should return true if the user is authenticated', (done) => {
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(of(mockChef));
     const guardResult = executeGuard(route, state) as Observable<boolean>;
@@ -69,7 +73,24 @@ describe('authGuard', () => {
     });
   });
 
+  it("should redirect to the login page if there's no token in localStorage", () => {
+    spyOn(localStorageProto, 'getItem').and.returnValue(null);
+    mockChefService.chef.and.returnValue(undefined);
+    mockChefService.getChef.and.returnValue(throwError(() => 'mock error'));
+    const guardResult = executeGuard(route, state) as UrlTree;
+
+    expect(guardResult).toBeInstanceOf(UrlTree);
+    expect(guardResult.queryParams).toEqual({ next: state.url });
+    expect(createUrlTreeSpy).toHaveBeenCalledWith(
+      [`/${profileRoutes.login.path}`],
+      {
+        queryParams: { next: state.url },
+      }
+    );
+  });
+
   it("should redirect to the login page if the user isn't authenticated", (done) => {
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(throwError(() => 'mock error'));
     const guardResult = executeGuard(route, state) as Observable<UrlTree>;
@@ -88,6 +109,7 @@ describe('authGuard', () => {
   });
 
   it("should redirect to the login page if the user didn't verify their email", (done) => {
+    spyOn(localStorageProto, 'getItem').and.returnValue(mockToken);
     mockChefService.chef.and.returnValue(undefined);
     mockChefService.getChef.and.returnValue(
       of({

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -4,18 +4,22 @@ import { catchError, map, of } from 'rxjs';
 
 import { ChefService } from '../services/chef.service';
 import { profileRoutes } from '../app-routing.module';
+import Constants from '../constants/constants';
 
 // If the user is authenticated, navigate to the route. Otherwise, redirect to the login page.
 export const authGuard: CanActivateFn = (_route, state) => {
   const router = inject(Router);
   const chefService = inject(ChefService);
 
+  const token = localStorage.getItem(Constants.LocalStorage.token);
   const loginRedirect = router.createUrlTree([`/${profileRoutes.login.path}`], {
     // state.url contains the full path, whereas route.url only contains the child path
     queryParams: { next: state.url },
   });
 
-  if (chefService.chef() !== undefined) {
+  if (token === null) {
+    return loginRedirect;
+  } else if (chefService.chef() !== undefined) {
     return true;
   }
 

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -33,6 +33,13 @@ describe('ChefService', () => {
     'An unexpected error occurred. The server may be down or there may be network issues. ' +
     'Please try again later.';
 
+  const mockLocalStorage = (token: string | null = mockChef.token) => {
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
@@ -55,12 +62,16 @@ describe('ChefService', () => {
   });
 
   it('should get a chef', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.getChef());
 
     const req = httpTestingController.expectOne({
       method: 'GET',
       url: baseUrl,
     });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     req.flush(mockChef);
 
     await expectAsync(chefPromise).toBeResolvedTo(mockChef);
@@ -68,6 +79,7 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the GET chef API fails', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.getChef());
 
     const req = httpTestingController.expectOne({
@@ -81,6 +93,7 @@ describe('ChefService', () => {
   });
 
   it('should create a chef', async () => {
+    mockLocalStorage();
     const credentials: LoginCredentials = {
       email: mockChef.email,
       password: 'password',
@@ -91,6 +104,7 @@ describe('ChefService', () => {
       method: 'POST',
       url: baseUrl,
     });
+    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(credentials);
     const loginResponse = mockLoginResponse(false);
     req.flush(loginResponse);
@@ -112,6 +126,7 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.createChef(credentials));
 
     const req = httpTestingController.expectOne({
@@ -130,12 +145,16 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'newpassword',
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
       method: 'PATCH',
       url: baseUrl,
     });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     expect(req.request.body).toBe(fields);
     req.flush(mockChefEmailResponse);
 
@@ -147,12 +166,14 @@ describe('ChefService', () => {
       type: ChefUpdateType.Password,
       email: mockChef.email,
     };
+    mockLocalStorage(null);
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
       method: 'PATCH',
       url: baseUrl,
     });
+    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(fields);
     req.flush(mockChefEmailResponse);
 
@@ -164,6 +185,7 @@ describe('ChefService', () => {
       type: ChefUpdateType.Email,
       email: mockChef.email,
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.updateChef(fields));
 
     const req = httpTestingController.expectOne({
@@ -176,12 +198,16 @@ describe('ChefService', () => {
   });
 
   it('should delete a chef', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.deleteChef());
 
     const req = httpTestingController.expectOne({
       method: 'DELETE',
       url: baseUrl,
     });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     req.flush(null);
 
     await expectAsync(chefPromise).toBeResolvedTo(null);
@@ -189,6 +215,7 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the DELETE chef API fails', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.deleteChef());
 
     const req = httpTestingController.expectOne({
@@ -202,12 +229,16 @@ describe('ChefService', () => {
   });
 
   it('should verify an email', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.verifyEmail());
 
     const req = httpTestingController.expectOne({
       method: 'POST',
       url: `${baseUrl}/verify`,
     });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     expect(req.request.body).toBeNull();
     req.flush(mockChefEmailResponse);
 
@@ -215,6 +246,7 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the verify email API fails', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.verifyEmail());
 
     const req = httpTestingController.expectOne({
@@ -231,12 +263,14 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.login(credentials));
 
     const req = httpTestingController.expectOne({
       method: 'POST',
       url: `${baseUrl}/login`,
     });
+    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(credentials);
     const loginResponse = mockLoginResponse();
     req.flush(loginResponse);
@@ -258,6 +292,7 @@ describe('ChefService', () => {
       email: mockChef.email,
       password: 'password',
     };
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.login(credentials));
 
     const req = httpTestingController.expectOne({
@@ -271,12 +306,16 @@ describe('ChefService', () => {
   });
 
   it('should logout', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.logout());
 
     const req = httpTestingController.expectOne({
       method: 'POST',
       url: `${baseUrl}/logout`,
     });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     expect(req.request.body).toBeNull();
     req.flush(null);
 
@@ -285,6 +324,7 @@ describe('ChefService', () => {
   });
 
   it('should return an error if the logout API fails', async () => {
+    mockLocalStorage();
     const chefPromise = firstValueFrom(chefService.logout());
 
     const req = httpTestingController.expectOne({

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -1,11 +1,12 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, inject, signal } from '@angular/core';
-import { catchError, Observable, of, tap } from 'rxjs';
+import { catchError, Observable, of, tap, throwError } from 'rxjs';
 
 import {
   Chef,
   ChefEmailResponse,
   ChefUpdate,
+  ChefUpdateType,
   LoginCredentials,
   LoginResponse,
 } from '../models/profile.model';
@@ -34,16 +35,22 @@ export class ChefService {
       return of(mockChef);
     }
 
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      return this.noTokenFound();
+    }
+
     return this.http
       .get<Chef>(`${environment.serverBaseUrl}${Constants.chefsPath}`, {
-        // Required so the browser can send & store cookies
-        withCredentials: true,
+        headers: this.authHeader(token),
       })
       .pipe(
         tap((chef) => {
+          localStorage.setItem(Constants.LocalStorage.token, chef.token);
           this.chef.set(chef.emailVerified ? chef : undefined);
         }),
         catchError((error) => {
+          localStorage.removeItem(Constants.LocalStorage.token);
           return handleError(error);
         })
       );
@@ -58,10 +65,7 @@ export class ChefService {
     return this.http
       .post<LoginResponse>(
         `${environment.serverBaseUrl}${Constants.chefsPath}`,
-        credentials,
-        {
-          withCredentials: true,
-        }
+        credentials
       )
       .pipe(
         tap(({ uid, token, emailVerified }) => {
@@ -74,6 +78,7 @@ export class ChefService {
             favoriteRecipes: [],
             token,
           });
+          localStorage.setItem(Constants.LocalStorage.token, token);
         }),
         catchError(handleError)
       );
@@ -84,15 +89,38 @@ export class ChefService {
       return of(mockChefEmailResponse);
     }
 
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (
+      token === null &&
+      (fields.type !== ChefUpdateType.Password || fields.password !== undefined)
+    ) {
+      return this.noTokenFound();
+    }
+
     return this.http
       .patch<ChefEmailResponse>(
         `${environment.serverBaseUrl}${Constants.chefsPath}`,
         fields,
         {
-          withCredentials: true,
+          headers: {
+            ...(token !== null && this.authHeader(token)),
+          },
         }
       )
-      .pipe(catchError(handleError));
+      .pipe(
+        tap(({ token }) => {
+          if (token !== undefined && fields.type !== ChefUpdateType.Password) {
+            localStorage.setItem(Constants.LocalStorage.token, token);
+          } else if (
+            token !== undefined &&
+            fields.type === ChefUpdateType.Password
+          ) {
+            // The token will be revoked, so sign out the user
+            localStorage.removeItem(Constants.LocalStorage.token);
+          }
+        }),
+        catchError(handleError)
+      );
   }
 
   deleteChef(): Observable<null> {
@@ -101,12 +129,18 @@ export class ChefService {
       return of(null);
     }
 
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      return this.noTokenFound();
+    }
+
     return this.http
       .delete<null>(`${environment.serverBaseUrl}${Constants.chefsPath}`, {
-        withCredentials: true,
+        headers: this.authHeader(token),
       })
       .pipe(
         tap(() => {
+          localStorage.removeItem(Constants.LocalStorage.token);
           this.chef.set(undefined);
         }),
         catchError(handleError)
@@ -118,13 +152,25 @@ export class ChefService {
       return of(mockChefEmailResponse);
     }
 
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      return this.noTokenFound();
+    }
+
     return this.http
       .post<ChefEmailResponse>(
         `${environment.serverBaseUrl}${Constants.chefsPath}/verify`,
         null, // no body
-        { withCredentials: true }
+        { headers: this.authHeader(token) }
       )
-      .pipe(catchError(handleError));
+      .pipe(
+        tap(({ token }) => {
+          if (token !== undefined) {
+            localStorage.setItem(Constants.LocalStorage.token, token);
+          }
+        }),
+        catchError(handleError)
+      );
   }
 
   login(credentials: LoginCredentials): Observable<LoginResponse> {
@@ -136,13 +182,11 @@ export class ChefService {
     return this.http
       .post<LoginResponse>(
         `${environment.serverBaseUrl}${Constants.chefsPath}/login`,
-        credentials,
-        {
-          withCredentials: true,
-        }
+        credentials
       )
       .pipe(
         tap(({ uid, token, emailVerified }) => {
+          localStorage.setItem(Constants.LocalStorage.token, token);
           this.chef.set({
             uid,
             email: credentials.email,
@@ -163,19 +207,39 @@ export class ChefService {
       return of(null);
     }
 
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      // Assume the user should be signed out since there's no auth token
+      localStorage.removeItem(Constants.LocalStorage.token);
+      this.chef.set(undefined);
+      return of(null);
+    }
+
     return this.http
       .post<null>(
         `${environment.serverBaseUrl}${Constants.chefsPath}/logout`,
         null,
         {
-          withCredentials: true,
+          headers: this.authHeader(token),
         }
       )
       .pipe(
         tap(() => {
+          localStorage.removeItem(Constants.LocalStorage.token);
           this.chef.set(undefined);
         }),
         catchError(handleError)
       );
+  }
+
+  // Helpers
+  private authHeader(token: string) {
+    return {
+      Authorization: `Bearer ${token}`,
+    };
+  }
+
+  private noTokenFound() {
+    return throwError(() => new Error(Constants.noTokenFound));
   }
 }

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -19,6 +19,7 @@ import recipeFilterParams from './recipe-filter-params';
 import RecentRecipesDB, {
   RECENT_RECIPES_DB_NAME,
 } from '../helpers/recent-recipes-db';
+import { mockChef } from '../models/profile.mock';
 
 describe('RecipeService', () => {
   let recipeService: RecipeService;
@@ -39,6 +40,13 @@ describe('RecipeService', () => {
       isFavorite: false,
     })
   );
+
+  const mockLocalStorage = (token: string | null = mockChef.token) => {
+    const localStorageProto = Object.getPrototypeOf(localStorage);
+    spyOn(localStorageProto, 'getItem').and.returnValue(token);
+    spyOn(localStorageProto, 'setItem').and.callFake(() => undefined);
+    spyOn(localStorageProto, 'removeItem').and.callFake(() => undefined);
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -217,6 +225,7 @@ describe('RecipeService', () => {
       view: true,
       isFavorite: true,
     };
+    mockLocalStorage();
     const recipePromise = firstValueFrom(
       recipeService.updateRecipe(id, fields)
     );
@@ -225,6 +234,9 @@ describe('RecipeService', () => {
       method: 'PATCH',
       url: `${baseUrl}/${id}`,
     });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     expect(req.request.body).toBe(fields);
     req.flush(mockToken);
 
@@ -237,6 +249,7 @@ describe('RecipeService', () => {
     const fields: RecipeUpdate = {
       view: true,
     };
+    mockLocalStorage(null);
     const recipePromise = firstValueFrom(
       recipeService.updateRecipe(id, fields)
     );
@@ -245,6 +258,7 @@ describe('RecipeService', () => {
       method: 'PATCH',
       url: `${baseUrl}/${id}`,
     });
+    expect(req.request.headers.get('Authorization')).toBeNull();
     expect(req.request.body).toBe(fields);
     req.flush({});
 
@@ -257,6 +271,7 @@ describe('RecipeService', () => {
     const fields: RecipeUpdate = {
       isFavorite: false,
     };
+    mockLocalStorage();
     const recipePromise = firstValueFrom(
       recipeService.updateRecipe(id, fields)
     );
@@ -265,6 +280,9 @@ describe('RecipeService', () => {
       method: 'PATCH',
       url: `${baseUrl}/${id}`,
     });
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`
+    );
     expect(req.request.body).toBe(fields);
     req.error(mockError);
 


### PR DESCRIPTION
Reverts Abhiek187/ez-recipes-web#477

Tl;dr: Cookies weren't working across all browsers, so I'm reverting to using localStorage for the web app.

After testing cookie auth in prod, I ran into several issues. As it turns out, `SameSite=Strict` takes into account the full domain name, not just the first two levels. After I logged in, I was sent back to the login back and got a 401 error from the GET chef endpoint. After inspecting the login call, I saw this warning by the Set-Cookie header:

> This attempt to set a cookie via a Set-Cookie header was blocked because it had the "SameSite=Strict" attribute but came from a cross-site response which was not the response to a top-level navigaton.

By default, the domain of a cookie is set to the server's full domain, so I tried changing it to `onrender.com`. But then I got this error:

> This attempt to set a cookie via a Set-Cookie header was blocked because its Domain attribute was invalid with regards to the current host url.

I had no idea why Chrome thought the domain was invalid, but then ChatGPT let me know that browsers forbid cookies from having domains that are part of the Public Suffix List (PSL): https://publicsuffix.org/list/public_suffix_list.dat. And yep, Render was on that list:

> // Render : https://render.com
// Submitted by Anurag Goel <dev@render.com>
onrender.com
app.render.com

So are Fly.io, GitHub, & CloudFront:
> // fly.io : https://fly.io
// Submitted by Kurt Mackey <kurt@fly.io>
fly.dev
shw.io
edgeapp.net

> // GitHub, Inc.
// Submitted by Patrick Toomey <security@github.com>
github.app
githubusercontent.com
githubpreview.dev
github.io

> // Amazon CloudFront
// Submitted by Donavan Miller <donavanm@amazon.com>
// Reference: 54144616-fd49-4435-8535-19c6a601bdb3
cloudfront.net

This is another security measure to make sure not all users on these public domains have access to our cookie. (But again, I thought the CORS headers would prevent that issue...) So, I changed SameSite to None. (Lax wouldn't work in my case since I have more than just GET calls behind token auth.) This effectively strips any CSRF protection from the cookie, and now browsers will consider this a 3rd party cookie. These cookies are starting to be blocked by default to enhance the user's privacy.

Ok, now this works on Chrome and Firefox. (Side note: When I was testing this in Firefox and Safari, the Set-Cookie response header wasn't visible in dev tools, nor could I see the cookie under Storage. But, under the right conditions, the cookie was still getting passed to the APIs. This is because Set-Cookie is a [forbidden header](https://fetch.spec.whatwg.org/#forbidden-response-header-name), in which browsers are not allowed to access this header from an API. But Chromium browsers will show this anyway to help with debugging.)

But the login page still wasn't working in Safari, both on desktop and on mobile. I was warned about this from other devs, and it was true: Safari is more strict about cookies. It will only allow 3rd party cookies if "Prevent cross-site tracking" is disabled in Settings, but I can't expect all users to perform this step. This wouldn't work anyway in a PWA.

Now I'm left with 2 options:
1. Register a new domain for the cookie so it isn't part of the PSL. But this costs money, so I'd rather not for a personal project. 😄
2. Proxy all web requests to a `/api` path that redirects to the server. This negates the need for CORS since all requests would now be made under the web app's origin. If I don't set the cookie's domain, by default, it _should_ be set to the web's domain since that's where the request originated, but I haven't confirmed if this is the case. I know I'm not allowed to explicitly set the domain if it doesn't match the server's domain. Either way, this would require a bit of a refactor on the web app.

Maybe I could pursue option 2 in the future, but for simplicity's sake, I'll revert back to localStorage since that was already working. However, I'll keep the server changes since the cookies don't impact the mobile apps, and they shouldn't impact the web app since the auth middleware prioritizes the Authorization header over cookies. (And if the browser doesn't like the cookie, it can ignore it anyway.) I know other sites use cookies since they're more secure, but they have other ways to allow more strict usage. For reference, How to Stock's session cookie is able to be strict, HttpOnly, and secure since the server and website share the same domain (and the full domain isn't public). It stays valid for 2 weeks. This seems to be the case on other sites too.

Phew! This was a great learning experience about cookies, but man, can they be annoying to work with, given how much the browsers' privacy measures have evolved. 😮‍💨