### PR TITLE
Pass the state when logging in with OAuth

### DIFF
--- a/src/app/components/utils/oauth-button/oauth-button.component.spec.ts
+++ b/src/app/components/utils/oauth-button/oauth-button.component.spec.ts
@@ -79,7 +79,7 @@ describe('OauthButtonComponent', () => {
       new MessageEvent('message', {
         origin: 'https://www.example.com',
         data: undefined,
-      })
+      }),
     );
     fixture.detectChanges();
     await fixture.whenStable();
@@ -96,7 +96,7 @@ describe('OauthButtonComponent', () => {
           code: authUrl.searchParams.get('code'),
           state: '9876',
         },
-      })
+      }),
     );
     fixture.detectChanges();
     await fixture.whenStable();
@@ -112,7 +112,7 @@ describe('OauthButtonComponent', () => {
         data: {
           state: authUrl.searchParams.get('state'),
         },
-      })
+      }),
     );
     fixture.detectChanges();
     await fixture.whenStable();
@@ -130,13 +130,14 @@ describe('OauthButtonComponent', () => {
           code: authUrl.searchParams.get('code'),
           state: authUrl.searchParams.get('state'),
         },
-      })
+      }),
     );
     fixture.detectChanges();
     await fixture.whenStable();
 
     expect(mockLoginWithOAuth).toHaveBeenCalledWith({
       code: authUrl.searchParams.get('code'),
+      state: authUrl.searchParams.get('state'),
       providerId: component.provider(),
     });
     expect(successEmitSpy).toHaveBeenCalledWith(mockChef);

--- a/src/app/components/utils/oauth-button/oauth-button.component.ts
+++ b/src/app/components/utils/oauth-button/oauth-button.component.ts
@@ -43,7 +43,7 @@ export class OauthButtonComponent implements OnInit {
   isLoading = signal(false);
 
   readonly providerStyle = computed(
-    () => Constants.providerStyles[this.provider()]
+    () => Constants.providerStyles[this.provider()],
   );
   readonly providerIcon = computed(() => this.providerStyle().label);
   /* Keep track of which provider we're signing into
@@ -60,8 +60,8 @@ export class OauthButtonComponent implements OnInit {
     this.iconRegistry.addSvgIcon(
       this.providerIcon(),
       this.sanitizer.bypassSecurityTrustResourceUrl(
-        `assets/${this.providerStyle().icon}`
-      )
+        `assets/${this.providerStyle().icon}`,
+      ),
     );
   }
 
@@ -74,7 +74,7 @@ export class OauthButtonComponent implements OnInit {
     if (newWindow === null || newWindow.closed) {
       this.snackBar.open(
         'Pop-ups are required to sign in a new tab. Please enable them to continue.',
-        'Dismiss'
+        'Dismiss',
       );
     }
   }
@@ -97,6 +97,7 @@ export class OauthButtonComponent implements OnInit {
     const oAuthRequest: Parameters<typeof this.chefService.loginWithOAuth>[0] =
       {
         code: authCode,
+        state: authState,
         providerId: this.provider(),
       };
     this.chefService
@@ -105,7 +106,7 @@ export class OauthButtonComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
           this.isLoading.set(false);
-        })
+        }),
       )
       .subscribe({
         next: (chef) => {

--- a/src/app/models/profile.model.ts
+++ b/src/app/models/profile.model.ts
@@ -79,6 +79,7 @@ export interface AuthUrl {
 
 export interface OAuthRequest {
   code: string;
+  state: string;
   providerId: Provider;
   redirectUrl: string;
 }

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -378,6 +378,7 @@ describe('ChefService', () => {
   it('should login with an OAuth provider without a token', async () => {
     const oAuthRequest: Parameters<typeof chefService.loginWithOAuth>[0] = {
       code: 'code',
+      state: 'state',
       providerId: Provider.Google,
     };
     mockLocalStorage(null);
@@ -404,6 +405,7 @@ describe('ChefService', () => {
   it('should link an OAuth provider with a token', async () => {
     const oAuthRequest: Parameters<typeof chefService.loginWithOAuth>[0] = {
       code: 'code',
+      state: 'state',
       providerId: Provider.Google,
     };
     mockLocalStorage();
@@ -441,6 +443,7 @@ describe('ChefService', () => {
   it('should return an error if the OAuth login API fails', async () => {
     const oAuthRequest: Parameters<typeof chefService.loginWithOAuth>[0] = {
       code: 'code',
+      state: 'state',
       providerId: Provider.Google,
     };
     mockLocalStorage();


### PR DESCRIPTION
<img width="407" height="229" alt="image" src="https://github.com/user-attachments/assets/cba04cad-30d1-4858-87a3-5b8e5e4eafa8" />

_The web implementation of https://github.com/Abhiek187/ez-recipes-server/issues/530_

Luckily, we were already checking if the state matches what was passed in the GET /oauth endpoint (which was done to filter the button reacting to the message, but helped in hindsight 😉):

```ts
const authState = event.data?.state;
if (this.providerState() === null || authState !== this.providerState())
  return;
```

Therefore, the only change we needed to make was to pass the state to the POST /oauth endpoint. Once PKCE is enabled, this flow should continue to work as expected.