### PR TITLE
Add remember me toggle on the login form

### DIFF
--- a/src/app/components/profile/login/login.component.html
+++ b/src/app/components/profile/login/login.component.html
@@ -73,7 +73,7 @@
       </a>
     </h3>
   }
-  <mat-divider />
+  <mat-divider class="login-divider" />
 
   <h2>Or sign in using:</h2>
   <div class="oauth-button-container">

--- a/src/app/components/profile/login/login.component.html
+++ b/src/app/components/profile/login/login.component.html
@@ -62,7 +62,9 @@
     </mat-form-field>
   </div>
 
-  <mat-checkbox [formField]="loginForm.rememberMe">Remember Me</mat-checkbox>
+  <mat-checkbox [formField]="loginForm.rememberMe" class="remember-me-toggle">
+    Remember Me
+  </mat-checkbox>
 
   @if (!isStepUp()) {
     <h3>

--- a/src/app/components/profile/login/login.component.html
+++ b/src/app/components/profile/login/login.component.html
@@ -62,6 +62,8 @@
     </mat-form-field>
   </div>
 
+  <mat-checkbox [formField]="loginForm.rememberMe">Remember Me</mat-checkbox>
+
   @if (!isStepUp()) {
     <h3>
       <a [routerLink]="'/' + profileRoutes.forgotPassword.path">
@@ -69,6 +71,7 @@
       </a>
     </h3>
   }
+  <mat-divider />
 
   <h2>Or sign in using:</h2>
   <div class="oauth-button-container">

--- a/src/app/components/profile/login/login.component.scss
+++ b/src/app/components/profile/login/login.component.scss
@@ -10,6 +10,11 @@
   flex-direction: column;
 }
 
+.login-divider {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
 .oauth-button-container {
   display: flex;
   flex-wrap: wrap;

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -32,6 +32,10 @@ describe('LoginComponent', () => {
         .fn()
         .mockName('ChefService.getAuthUrls')
         .mockReturnValue(of(mockAuthUrls)),
+      getUsername: vi
+        .fn()
+        .mockName('ChefService.getUsername')
+        .mockReturnValue(null),
     } as unknown as ChefService);
 
     await TestBed.configureTestingModule({
@@ -80,6 +84,9 @@ describe('LoginComponent', () => {
     fixture.detectChanges();
     expect(passwordField.type).toBe('password');
 
+    const rememberMeToggle = rootElement.querySelector('.remember-me-toggle');
+    expect(rememberMeToggle).toBeDefined();
+    expect(rememberMeToggle?.textContent).toContain('Remember Me');
     expect(rootElement.querySelectorAll('.oauth-button').length).toBe(
       mockAuthUrls.length,
     );

--- a/src/app/components/profile/login/login.component.spec.ts
+++ b/src/app/components/profile/login/login.component.spec.ts
@@ -91,6 +91,7 @@ describe('LoginComponent', () => {
     loginForm.value.set({
       username: '',
       password: '',
+      rememberMe: false,
     });
     fixture.detectChanges();
 
@@ -115,6 +116,7 @@ describe('LoginComponent', () => {
     loginForm.value.set({
       username: mockEmail,
       password: mockPassword,
+      rememberMe: true,
     });
     fixture.detectChanges();
 

--- a/src/app/components/profile/login/login.component.ts
+++ b/src/app/components/profile/login/login.component.ts
@@ -2,6 +2,8 @@ import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { form, FormField, required } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -21,6 +23,8 @@ import { PasskeyButtonComponent } from '../../utils/passkey-button/passkey-butto
   imports: [
     FormField,
     MatButtonModule,
+    MatCheckboxModule,
+    MatDividerModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
@@ -47,8 +51,9 @@ export class LoginComponent implements OnInit {
   isStepUp = signal(false);
   authUrls = signal<Partial<Record<Provider, string>>>({});
   private loginModel = signal({
-    username: '',
+    username: this.chefService.getUsername() ?? '',
     password: '',
+    rememberMe: false,
   });
 
   loginForm = form(this.loginModel, ({ username, password }) => {
@@ -122,6 +127,11 @@ export class LoginComponent implements OnInit {
         state: { email },
       });
     } else {
+      if (email !== null && this.loginForm().value().rememberMe) {
+        // Autofill the username to make it easier to login in the future
+        this.chefService.saveUsername(email);
+      }
+
       // If a redirect URL is present in the query params, navigate to it
       // Otherwise, navigate to the profile page
       const redirectUrl = this.route.snapshot.queryParamMap.get('next');

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -58,6 +58,7 @@ abstract class Constants {
     static readonly terms = 'terms';
     static readonly token = 'token';
     static readonly theme = 'theme';
+    static readonly rememberMe = 'rememberMe';
   };
 
   // IndexedDB

--- a/src/app/helpers/array.spec.ts
+++ b/src/app/helpers/array.spec.ts
@@ -27,8 +27,8 @@ describe('getRandomElement', () => {
     // When getRandomElement() is called
     // Then the function should throw an error stating that the array
     // must contain at least one element
-    expect(() => getRandomElement(emptyArray)).toThrowError(
-      'The array must contain at least one element to be randomly selected.'
+    expect(() => getRandomElement(emptyArray)).toThrow(
+      'The array must contain at least one element to be randomly selected.',
     );
   });
 });

--- a/src/app/models/profile.model.ts
+++ b/src/app/models/profile.model.ts
@@ -4,6 +4,11 @@ export enum AuthState {
   Loading,
 }
 
+export interface RememberMe {
+  username: string;
+  expireAt: number;
+}
+
 export interface Chef {
   uid: string;
   email: string;

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -27,6 +27,7 @@ import {
   Provider,
 } from '../models/profile.model';
 import { mockToken } from '../models/recipe.mock';
+import { mockDate } from '../models/term-store.mock';
 
 describe('ChefService', () => {
   let chefService: ChefService;
@@ -58,10 +59,14 @@ describe('ChefService', () => {
 
     chefService = TestBed.inject(ChefService);
     httpTestingController = TestBed.inject(HttpTestingController);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
   });
 
   afterEach(() => {
     httpTestingController.verify();
+    vi.useRealTimers();
   });
 
   it('should be created', () => {
@@ -95,7 +100,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
   });
 
@@ -144,7 +149,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
   });
 
@@ -203,7 +208,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should delete a chef', async () => {
@@ -233,7 +238,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
   });
 
@@ -264,7 +269,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should login', async () => {
@@ -312,7 +317,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
   });
 
@@ -344,7 +349,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
   });
 
@@ -371,7 +376,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should login with an OAuth provider without a token', async () => {
@@ -398,7 +403,7 @@ describe('ChefService', () => {
     oauthReq.flush(loginResponse);
 
     // Since localStorage is mocked to not have a token, GET chef fails in this case
-    await expect(chefPromise).rejects.toThrowError(Constants.noTokenFound);
+    await expect(chefPromise).rejects.toThrow(Constants.noTokenFound);
   });
 
   it('should link an OAuth provider with a token', async () => {
@@ -456,7 +461,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should unlink an OAuth provider', async () => {
@@ -501,7 +506,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
   });
 
@@ -531,7 +536,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should get an existing passkey challenge', async () => {
@@ -561,7 +566,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should validate a new passkey', async () => {
@@ -643,7 +648,7 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
   });
 
@@ -685,7 +690,32 @@ describe('ChefService', () => {
     });
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(chefService.chef()).toBeUndefined();
+  });
+
+  it('should get the saved username if not expired', async () => {
+    mockLocalStorage(
+      JSON.stringify({
+        username: mockChef.email,
+        expireAt: mockDate.getTime() * 2,
+      }),
+    );
+    expect(chefService.getUsername()).toBe(mockChef.email);
+  });
+
+  it('should return null if no username is saved', async () => {
+    mockLocalStorage(null);
+    expect(chefService.getUsername()).toBeNull();
+  });
+
+  it('should return null if the username has expired', async () => {
+    mockLocalStorage(
+      JSON.stringify({
+        username: mockChef.email,
+        expireAt: mockDate.getTime() / 2,
+      }),
+    );
+    expect(chefService.getUsername()).toBe(null);
   });
 });

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -12,6 +12,7 @@ import {
   LoginResponse,
   OAuthRequest,
   Provider,
+  RememberMe,
 } from '../models/profile.model';
 import { environment } from 'src/environments/environment';
 import Constants from '../constants/constants';
@@ -450,6 +451,48 @@ export class ChefService {
         }),
         catchError(handleError),
       );
+  }
+
+  // localStorage methods
+  getUsername(): string | null {
+    const rememberMeStr = localStorage.getItem(
+      Constants.LocalStorage.rememberMe,
+    );
+    if (rememberMeStr === null) return null;
+    const rememberMe: RememberMe = JSON.parse(rememberMeStr);
+
+    // Delete the username if it's expired
+    if (Date.now() >= rememberMe.expireAt) {
+      localStorage.removeItem(Constants.LocalStorage.rememberMe);
+      return null;
+    }
+
+    return rememberMe.username;
+  }
+
+  saveUsername(username?: string) {
+    let newUsername: string;
+
+    if (username !== undefined) {
+      newUsername = username;
+    } else {
+      // If no username is provided, use the existing username saved
+      const existingUsername = this.getUsername();
+
+      if (existingUsername !== null) {
+        newUsername = existingUsername;
+      } else {
+        // If no username is saved, don't do anything
+        return;
+      }
+    }
+
+    const rememberMe: RememberMe = {
+      username: newUsername,
+      expireAt: Date.now() + 30 * 24 * 60 * 60 * 1000, // 1 month
+    };
+    const rememberMeStr = JSON.stringify(rememberMe);
+    localStorage.setItem(Constants.LocalStorage.rememberMe, rememberMeStr);
   }
 
   // Helpers

--- a/src/app/services/recipe.service.spec.ts
+++ b/src/app/services/recipe.service.spec.ts
@@ -128,7 +128,7 @@ describe('RecipeService', () => {
     // Respond with mock error
     req.error(mockError);
 
-    await expect(chefPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
     expect(recipeService.recipe()).toBeNull();
   });
 
@@ -158,7 +158,7 @@ describe('RecipeService', () => {
     });
     req.error(mockError);
 
-    await expect(recipePromise).rejects.toThrowError(mockErrorMessage);
+    await expect(recipePromise).rejects.toThrow(mockErrorMessage);
     expect(recipeService.recipe()).toBeNull();
   });
 
@@ -221,7 +221,7 @@ describe('RecipeService', () => {
     });
     req.error(mockError);
 
-    await expect(recipePromise).rejects.toThrowError(mockErrorMessage);
+    await expect(recipePromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should update a recipe', async () => {
@@ -293,7 +293,7 @@ describe('RecipeService', () => {
     expect(req.request.body).toBe(fields);
     req.error(mockError);
 
-    await expect(recipePromise).rejects.toThrowError(mockErrorMessage);
+    await expect(recipePromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should generate a PDF', async () => {
@@ -320,7 +320,7 @@ describe('RecipeService', () => {
     });
     req.error(mockError);
 
-    await expect(recipePromise).rejects.toThrowError(mockErrorMessage);
+    await expect(recipePromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should return a mock recipe', async () => {

--- a/src/app/services/terms.service.spec.ts
+++ b/src/app/services/terms.service.spec.ts
@@ -79,7 +79,7 @@ describe('TermsService', () => {
     });
     req.error(mockError);
 
-    await expect(termsPromise).rejects.toThrowError(mockErrorMessage);
+    await expect(termsPromise).rejects.toThrow(mockErrorMessage);
   });
 
   it('should return null if no terms are stored in localStorage', () => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/d3ef2e7a-b8b6-4b9f-9a64-36ef5ffbc75b

<img width="408" height="372" alt="remember-me-localstorage" src="https://github.com/user-attachments/assets/73b6c4da-4589-4d21-83d9-038279918c9c" />

_The partial web implementation of https://github.com/Abhiek187/ez-recipes-web/issues/558_

Not much to say here. Adding the toggle to the signal form was straightforward. We don't need to worry about overflows since these are well under 10^308 😉