### PR TITLE
Add an option to rename passkeys

### DIFF
--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -97,6 +97,13 @@
             <h3 class="profile-passkey-name">{{ passkey.name }}</h3>
             <button
               mat-icon-button
+              aria-label="Rename passkey"
+              (click)="renamePasskey(passkey)"
+            >
+              <mat-icon fontIcon="edit" />
+            </button>
+            <button
+              mat-icon-button
               class="icon-warn"
               aria-label="Delete passkey"
               (click)="deletePasskey(passkey)"

--- a/src/app/components/profile/profile.component.spec.ts
+++ b/src/app/components/profile/profile.component.spec.ts
@@ -154,9 +154,11 @@ describe('ProfileComponent', () => {
         '.profile-passkey-container',
       )?.[passkeyI];
       expect(passkeyContainer?.textContent).toContain(passkey.name);
-      const deletePasskeyButton =
-        passkeyContainer?.querySelector<HTMLButtonElement>('button');
-      expect(deletePasskeyButton?.ariaLabel).toBe('Delete passkey');
+      const passkeyButtons =
+        passkeyContainer?.querySelectorAll<HTMLButtonElement>('button');
+      expect(passkeyButtons?.length).toBe(2);
+      expect(passkeyButtons?.[0].ariaLabel).toBe('Rename passkey');
+      expect(passkeyButtons?.[1].ariaLabel).toBe('Delete passkey');
       expect(passkeyContainer?.textContent).toContain('Last used');
     }
 

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -28,7 +28,11 @@ import { profileRoutes } from 'src/app/app-routing.module';
 import Constants from 'src/app/constants/constants';
 import { ChefService } from 'src/app/services/chef.service';
 import { OauthButtonComponent } from '../utils/oauth-button/oauth-button.component';
-import { DialogComponent, DialogData } from '../utils/dialog/dialog.component';
+import {
+  DialogComponent,
+  DialogData,
+  DialogResult,
+} from '../utils/dialog/dialog.component';
 import Theme from 'src/app/models/theme.model';
 import { PasskeyButtonComponent } from '../utils/passkey-button/passkey-button.component';
 import { base64URLEncode } from 'src/app/helpers/string';
@@ -170,8 +174,7 @@ export class ProfileComponent implements OnInit {
     // Sync passkeys and the username with all authenticators
     try {
       if (Object.hasOwn(PublicKeyCredential, 'signalAllAcceptedCredentials')) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await (PublicKeyCredential as any).signalAllAcceptedCredentials({
+        await PublicKeyCredential.signalAllAcceptedCredentials({
           rpId: location.hostname,
           userId: base64URLEncode(chef.uid),
           allAcceptedCredentialIds: chef.passkeys.map(
@@ -187,8 +190,7 @@ export class ProfileComponent implements OnInit {
         );
       }
       if (Object.hasOwn(PublicKeyCredential, 'signalCurrentUserDetails')) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await (PublicKeyCredential as any).signalCurrentUserDetails({
+        await PublicKeyCredential.signalCurrentUserDetails({
           rpId: location.hostname,
           userId: base64URLEncode(chef.uid),
           name: chef.email,
@@ -243,20 +245,21 @@ export class ProfileComponent implements OnInit {
 
   openUnlinkAlert(provider: Provider) {
     // Confirm before unlinking
-    const dialogRef = this.dialog.open<DialogComponent, DialogData>(
+    const dialogRef = this.dialog.open<
       DialogComponent,
-      {
-        data: {
-          message: `Are you sure you want to unlink ${provider}?`,
-          dismissText: 'No',
-          confirmText: 'Yes',
-          isConfirmDestructive: true,
-        },
+      DialogData,
+      DialogResult
+    >(DialogComponent, {
+      data: {
+        message: `Are you sure you want to unlink ${provider}?`,
+        dismissText: 'No',
+        confirmText: 'Yes',
+        isConfirmDestructive: true,
       },
-    );
+    });
 
-    dialogRef.afterClosed().subscribe((didConfirm: boolean) => {
-      if (!didConfirm) return;
+    dialogRef.afterClosed().subscribe((result) => {
+      if (!result?.didConfirm) return;
       this.isLoading.set(true);
       this.selectedProvider.set(provider);
 
@@ -279,22 +282,58 @@ export class ProfileComponent implements OnInit {
     });
   }
 
+  renamePasskey(passkey: Passkey) {
+    const dialogRef = this.dialog.open<
+      DialogComponent,
+      DialogData,
+      DialogResult
+    >(DialogComponent, {
+      data: {
+        inputLabel: 'Rename Passkey',
+        input: passkey.name,
+        dismissText: 'Cancel',
+        confirmText: 'OK',
+      },
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (!result?.didConfirm || !result?.input) return;
+      this.isLoading.set(true);
+
+      this.chefService
+        .updatePasskeyName(passkey.id, result.input)
+        .pipe(
+          takeUntilDestroyed(this.destroyRef),
+          finalize(() => {
+            this.isLoading.set(false);
+          }),
+        )
+        .subscribe({
+          // Visual confirmation should be sufficient
+          error: (error) => {
+            this.snackBar.open(error.message, 'Dismiss');
+          },
+        });
+    });
+  }
+
   deletePasskey(passkey: Passkey) {
     // Confirm before deleting a passkey
-    const dialogRef = this.dialog.open<DialogComponent, DialogData>(
+    const dialogRef = this.dialog.open<
       DialogComponent,
-      {
-        data: {
-          message: `Are you sure you want to delete this passkey? ${passkey.name}`,
-          dismissText: 'No',
-          confirmText: 'Yes',
-          isConfirmDestructive: true,
-        },
+      DialogData,
+      DialogResult
+    >(DialogComponent, {
+      data: {
+        message: `Are you sure you want to delete this passkey? ${passkey.name}`,
+        dismissText: 'No',
+        confirmText: 'Yes',
+        isConfirmDestructive: true,
       },
-    );
+    });
 
-    dialogRef.afterClosed().subscribe((didConfirm: boolean) => {
-      if (!didConfirm) return;
+    dialogRef.afterClosed().subscribe((result) => {
+      if (!result?.didConfirm) return;
       this.isLoading.set(true);
 
       this.chefService
@@ -309,8 +348,7 @@ export class ProfileComponent implements OnInit {
           next: async () => {
             // Signal all authenticators to delete the passkey
             if (Object.hasOwn(PublicKeyCredential, 'signalUnknownCredential')) {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              await (PublicKeyCredential as any).signalUnknownCredential({
+              await PublicKeyCredential.signalUnknownCredential({
                 rpId: location.hostname,
                 credentialId: passkey.id,
               });

--- a/src/app/components/utils/dialog/dialog.component.html
+++ b/src/app/components/utils/dialog/dialog.component.html
@@ -4,16 +4,28 @@
 <mat-dialog-content>
   <p>{{ message }}</p>
 </mat-dialog-content>
+@if (input !== undefined) {
+  <mat-form-field class="dialog-form-field">
+    @if (inputLabel !== undefined) {
+      <mat-label>{{ inputLabel }}</mat-label>
+    }
+    <input matInput [formField]="inputForm" />
+    @if (inputForm().getError("required") !== undefined) {
+      <mat-error>{{ inputForm().getError("required")?.message }}</mat-error>
+    }
+  </mat-form-field>
+}
 <mat-dialog-actions>
   @if (dismissText !== undefined) {
-    <button mat-raised-button [mat-dialog-close]="false">
+    <button mat-raised-button [mat-dialog-close]="{ didConfirm: false }">
       {{ dismissText }}
     </button>
   }
   <button
     mat-raised-button
-    [mat-dialog-close]="true"
+    [mat-dialog-close]="{ didConfirm: true, input: inputForm().value() }"
     [class.btn-warn]="isConfirmDestructive"
+    [disabled]="inputForm().invalid()"
   >
     {{ confirmText }}
   </button>

--- a/src/app/components/utils/dialog/dialog.component.scss
+++ b/src/app/components/utils/dialog/dialog.component.scss
@@ -1,0 +1,3 @@
+.dialog-form-field {
+  margin: 0 8px;
+}

--- a/src/app/components/utils/dialog/dialog.component.spec.ts
+++ b/src/app/components/utils/dialog/dialog.component.spec.ts
@@ -11,6 +11,8 @@ describe('DialogComponent', () => {
   const dialogData: DialogData = {
     title: 'Title',
     message: 'This is a test',
+    input: '',
+    inputLabel: 'Type something',
     dismissText: 'Back',
     confirmText: 'Continue',
   };
@@ -37,7 +39,23 @@ describe('DialogComponent', () => {
     expect(component).toBeTruthy();
     expect(rootElement.textContent).toContain(dialogData.title);
     expect(rootElement.textContent).toContain(dialogData.message);
+    expect(rootElement.textContent).toContain(dialogData.inputLabel);
     expect(rootElement.textContent).toContain(dialogData.dismissText);
     expect(rootElement.textContent).toContain(dialogData.confirmText);
+  });
+
+  it('should disable the confirm button until input is provided', () => {
+    const inputForm = component.inputForm();
+    const confirmButton =
+      rootElement.querySelectorAll<HTMLButtonElement>('button')[1];
+
+    expect(inputForm.invalid()).toBe(true);
+    expect(inputForm.getError('required')).not.toBeUndefined();
+    expect(confirmButton.disabled).toBe(true);
+
+    inputForm.value.set('something');
+    fixture.detectChanges();
+    expect(inputForm.valid()).toBe(true);
+    expect(confirmButton.disabled).toBe(false);
   });
 });

--- a/src/app/components/utils/dialog/dialog.component.ts
+++ b/src/app/components/utils/dialog/dialog.component.ts
@@ -1,18 +1,34 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { form, FormField, required } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 
 export interface DialogData {
   title?: string;
-  message: string;
+  message?: string;
+  input?: string;
+  inputLabel?: string;
   dismissText?: string;
   confirmText?: string;
   isConfirmDestructive?: boolean;
 }
 
+export interface DialogResult {
+  didConfirm: boolean;
+  input?: string;
+}
+
 @Component({
   selector: 'app-dialog',
-  imports: [MatButtonModule, MatDialogModule],
+  imports: [
+    FormField,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
   templateUrl: './dialog.component.html',
   styleUrl: './dialog.component.scss',
 })
@@ -21,7 +37,18 @@ export class DialogComponent {
 
   readonly title = this.dialogData.title;
   readonly message = this.dialogData.message;
+  readonly input = this.dialogData.input;
+  readonly inputLabel = this.dialogData.inputLabel;
   readonly dismissText = this.dialogData.dismissText;
   readonly confirmText = this.dialogData.confirmText ?? 'OK';
   readonly isConfirmDestructive = this.dialogData.isConfirmDestructive ?? false;
+
+  // Pre-fill input if provided
+  private _input = signal(this.input ?? '');
+  inputForm = form(this._input, (_input) => {
+    // Ignore validations if no input was provided
+    if (this.input !== undefined) {
+      required(_input, { message: 'This field is required' });
+    }
+  });
 }

--- a/src/app/components/utils/passkey-button/passkey-button.component.ts
+++ b/src/app/components/utils/passkey-button/passkey-button.component.ts
@@ -126,11 +126,11 @@ export class PasskeyButtonComponent {
       if (
         passkeyCredential !== null &&
         options !== null &&
+        options.rp.id !== undefined &&
         Object.hasOwn(PublicKeyCredential, 'signalUnknownCredential')
       ) {
         try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          await (PublicKeyCredential as any).signalUnknownCredential({
+          await PublicKeyCredential.signalUnknownCredential({
             rpId: options.rp.id,
             credentialId: passkeyCredential.id,
           });

--- a/src/app/services/chef.service.spec.ts
+++ b/src/app/services/chef.service.spec.ts
@@ -652,6 +652,51 @@ describe('ChefService', () => {
     expect(chefService.chef()).toBeUndefined();
   });
 
+  it("should update the passkey's name", async () => {
+    const id = 'abc123';
+    const name = 'new passkey';
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.updatePasskeyName(id, name));
+
+    const patchReq = httpTestingController.expectOne({
+      method: 'PATCH',
+      url: `${baseUrl}/passkey`,
+    });
+    expect(patchReq.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`,
+    );
+    expect(patchReq.request.body).toStrictEqual({ id, name });
+    patchReq.flush(mockToken);
+
+    const chefReq = httpTestingController.expectOne({
+      method: 'GET',
+      url: baseUrl,
+    });
+    expect(chefReq.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockChef.token}`,
+    );
+    chefReq.flush(mockChef);
+
+    await expect(chefPromise).resolves.toBe(mockChef);
+    expect(chefService.chef()).toBe(mockChef);
+  });
+
+  it('should return an error if the update passkey API fails', async () => {
+    const id = 'abc123';
+    const name = 'new passkey';
+    mockLocalStorage();
+    const chefPromise = firstValueFrom(chefService.updatePasskeyName(id, name));
+
+    const req = httpTestingController.expectOne({
+      method: 'PATCH',
+      url: `${baseUrl}/passkey`,
+    });
+    req.error(mockError);
+
+    await expect(chefPromise).rejects.toThrow(mockErrorMessage);
+    expect(chefService.chef()).toBeUndefined();
+  });
+
   it('should delete a passkey', async () => {
     const id = 'abc123';
     mockLocalStorage();

--- a/src/app/services/chef.service.ts
+++ b/src/app/services/chef.service.ts
@@ -420,6 +420,40 @@ export class ChefService {
       );
   }
 
+  updatePasskeyName(id: string, name: string): Observable<Chef> {
+    if (this.isMocking) {
+      return of(mockChef);
+    }
+
+    const token = localStorage.getItem(Constants.LocalStorage.token);
+    if (token === null) {
+      return this.noTokenFound();
+    }
+
+    return this.http
+      .patch<Token>(
+        `${environment.serverBaseUrl}${Constants.chefsPath}/passkey`,
+        {
+          id,
+          name,
+        },
+        {
+          headers: this.authHeader(token),
+        },
+      )
+      .pipe(
+        switchMap(({ token }) => {
+          if (token !== undefined) {
+            localStorage.setItem(Constants.LocalStorage.token, token);
+          }
+
+          // Get the chef's updated passkeys
+          return this.getChef();
+        }),
+        catchError(handleError),
+      );
+  }
+
   deletePasskey(id: string): Observable<Chef> {
     if (this.isMocking) {
       return of(mockChef);


### PR DESCRIPTION
https://github.com/user-attachments/assets/62a1ffa5-9dd1-47d6-bf12-ae53d5f73800

_The web implementation of https://github.com/Abhiek187/ez-recipes-web/issues/558_

I added an edit button next to each passkey so chefs can rename them. The demo above is something I've been wanting to do for a while. There's not much else to say here, other than the fact that I used signal forms to add an input field to the dialog component. If the input is blank, we disable the confirm button. And like the other buttons, as soon as the API is successful, the profile will be updated.

In case you're wondering, yes, you can make the passkey name as long as you want, and it'll fit right in! 😉
<img width="206" height="86" alt="image" src="https://github.com/user-attachments/assets/3f97e04c-46f8-4869-92cd-c194cd4caec6" />